### PR TITLE
Add weasyprint and render a PDF from the site sources.

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -25,6 +25,12 @@ jobs:
 
       - name: Build
         run: hugo
+
+      - name: Install weasyprint
+        run: sudo apt install weasyprint
+
+      - name: Build PDF
+        run: hugo server --disableFastRender -verbose --config config-pdf.yaml & sleep 30 && weasyprint -v http://localhost:1313/dtdocs/index.html ./public/darktable_user_manual.pdf && pkill hugo
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/content/_index.html
+++ b/content/_index.html
@@ -11,3 +11,6 @@ author: "people"
 <p>
 The source repository for this documentation may be found at <a href="https://github.com/darktable-org/dtdocs.git">https://github.com/darktable-org/dtdocs.git</a>. Any feedback relating to this documentation can be provided by creating a <a href="https://github.com/darktable-org/dtdocs/issues/new">ticket</a> or a pull request against this repository.
 </p>
+<p>
+You can obtain this manual in PDF format <a href="darktable_user_manual.pdf">here</a>.
+</p>


### PR DESCRIPTION
Auto generates a PDF of the docs. Fixes #144.