### PR TITLE
Update hugo-darktable-docs-theme to github address.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://gitlab.com/pixlsus/hugo-bootstrap-bare.git
 [submodule "themes/hugo-darktable-docs-theme"]
 	path = themes/hugo-darktable-docs-theme
-	url = https://gitlab.com/pixlsus/hugo-darktable-docs-theme.git
+	url = https://github.com/pixlsus/hugo-darktable-docs-theme.git
 [submodule "themes/hugo-pdf-theme"]
 	path = themes/hugo-pdf-theme
 	url = https://gitlab.com/pixlsus/hugo-pdf-theme.git


### PR DESCRIPTION
Moved hugo-darktable-docs-theme to github under the pixlus group.