### PR TITLE
Updated slideshow section

### DIFF
--- a/content/slideshow/overview.md
+++ b/content/slideshow/overview.md
@@ -5,8 +5,8 @@ weight: 10
 draft: false
 author: "people"
 ---
-The slideshow view allows you to watch a slideshow of your current collection. Entering the slideshow view will start the slideshow, using the currently selected collection with the associated filtering rules and sort order applied. To learn more about how to define the collection and filtering rules, see the section on [collections](../lighttable/digital-asset-management/collections.md). Select the sort criteria and sort order of the images in the [top panel](../overview/user-interface/top-panel.md).
+The slideshow view allows you to watch a slideshow of your current collection with the associated filtering rules and sort order applied. 
 
-The image display is optimized to take full advantage of your screen size. Put darktable into fullscreen mode by pressing F11. Press the Tab key to hide all remaining panels, including the the filtering option in the top panel.
+To learn more about how to define the collection and filtering rules, see the section on [collections](../lighttable/digital-asset-management/collections.md). Select the sort criteria and sort order of the images in the [top panel](../overview/user-interface/top-panel.md).
 
 The next section provides more details on the [usage](usage.md) of the slideshow view.

--- a/content/slideshow/usage.md
+++ b/content/slideshow/usage.md
@@ -6,10 +6,17 @@ draft: false
 author: "people"
 ---
 
-The slideshow view is in an early stage of development with only a basic set of features.
+The slideshow view is still in an early stage of development with only a basic set of features.
+
+If you don't need the auto-advance mode, you could even use the [sticky-preview feature](../lighttable/lighttable-modes/full-preview.md) instead.
 
 ```
-F11                  toggle full-screen mode.
+
+spacebar             start and stop auto-advance mode which automatically switches
+                     to the next images every five seconds by default.
+
+ESC                  leave slideshow mode and return to lighttable view.
+
 
 + or                 increase delay between each image.
 up arrow 
@@ -19,17 +26,17 @@ down arrow
 
 left-click or        
 right arrow or       switch to the next image of the collection.
-shift+right arrow
+right shift-key
 
 right-click or       
 left arrow or        switch to the previous image of the collection.
-shift+left arrow
+left shift-key
 
-spacebar             start and stop auto-advance mode which automatically switches
-                     to the next images every five seconds by default.
-
-ESC                  leave slideshow mode and return to lighttable view.
 ```
 
-Depending on the complexity of the history stack and the power of your hardware, processing an image with high resolution can take a significant amount of time. In order to minimise latencies, darktable prefetches the next image in the background. If you still experience long delays when switching between images or if you intend to quickly advance in your collection, consider disabling the option [preferences > other views > slideshow > do high quality processing for slideshow](../preferences-settings/other-views.md). This allows the slideshow to proceed at a higher speed, at the expense of a slight loss in quality.
+---
+
+**Hint:** To take full advantage of your screen size, put darktable into fullscreen mode by pressing `F11` and hide the border-controls by pressing the key `b`.
+
+---
 


### PR DESCRIPTION
2nd attempt to update slideshow section (replaces #164)

Thanks to TurboGit and elstoc the limitations of the slideshow have been fixed (+/- keys) or clarified (left/right shift-key) - see https://github.com/darktable-org/darktable/issues/7128.

So I just removed the misleading wording 'Entering ... will start the slideshow', the not-existing preference-setting and the tab key which is not necessary anymore because panels are hidden automatically.

I moved the F11 key to the Hint-Section at the bottom, because it's no slideshow-specific function.

Finally I added a reference to the similar sticky-preview-feature and put the most-important spacebar and ESC to the top.

I hope that's ok - counter-proposal welcome!
