### PR TITLE
Bump hugo version and try to apt update before installing weasyprint.

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.76.5'
+          hugo-version: '0.79.0'
           extended: true
 
       - name: npm Install
@@ -27,7 +27,7 @@ jobs:
         run: hugo
 
       - name: Install weasyprint
-        run: sudo apt install weasyprint
+        run: sudo apt update && sudo apt install weasyprint
 
       - name: Build PDF
         run: hugo server --disableFastRender -verbose --config config-pdf.yaml & sleep 30 && weasyprint -v http://localhost:1313/dtdocs/index.html ./public/darktable_user_manual.pdf && pkill hugo


### PR DESCRIPTION
CI was failing because it couldn't find the python3-lxml deb in the right version. 