### PR TITLE
histogram profile: clarify when it is used

### DIFF
--- a/content/module-reference/utility-modules/darkroom/clipping.md
+++ b/content/module-reference/utility-modules/darkroom/clipping.md
@@ -16,6 +16,8 @@ There are two ways in which a pixel might become clipped when represented in the
 
 The "clipping warning" module is used to highlight those pixels that cannot be accurately represented in the output color space, either due to luminance or gamut clipping. Prior to darktable 3.4, the clipping highlighted any pixels that exceeded the maximum allowed value on any of the [R,G,B] channels, or that had been completely crushed to black. From darktable 3.4 onwards, the clipping warning indicator has some additional modes to help you to differentiate between luminance and gamut clipping, so that you can make better decisions about how to address any issues.
 
+As the clipping warning runs at the end of the preview pixelpipe, it receives data in display color space then converts it to histogram color space. If you are using a display color space which is not "well behaved" (this is common for a device profile), then colors which are outside of the gamut of the display profile will clip or distort.
+
 ![clipping-menu](./clipping/clipping-menu.png#w33)
 
 The clipping warning module, described here, deals with clipping caused by image processing and the limitations of the output color space. It should not be confused with the following similar tools:
@@ -29,9 +31,9 @@ The clipping warning module, described here, deals with clipping caused by image
 clipping preview mode
 : This allows you to choose which type of clipping you want the indicator to highlight, and can be one of the following:
 
-: - _any RGB channel_: Provides an over-clipping indication if any one of the three [R,G,G] channels exceeds the maximum permitted value for the output color space, or an under-clipping indication if the three [R,G,B] channels are too dark and are all forced to black. This was the default mode prior to darktable version 3.4.
+: - _any RGB channel_: Provides an over-clipping indication if any one of the three [R,G,G] channels exceeds the maximum permitted value for the histogram color space, or an under-clipping indication if the three [R,G,B] channels are too dark and are all forced to black. This was the default mode prior to darktable version 3.4.
 : - _luminance only_: Indicates any pixels that are clipped because their luminance falls outside of the range set in the "upper threshold" and "lower threshold" sliders. If this happens, it generally means that tone mapping or exposure settings have been poorly set
-: - _saturation only_: Indicates where over-saturated colors have pushed one or more of the [R,G,B] channels towards a value outside the permitted range of the output color space, even though the overall luminance of the pixel may lie within acceptable limits. This means this pixel color is imposible to represent in the target color space, and can arise from poorly set gamut mapping or saturation settings,
+: - _saturation only_: Indicates where over-saturated colors have pushed one or more of the [R,G,B] channels towards a value outside the permitted range of the histogram color space, even though the overall luminance of the pixel may lie within acceptable limits. This means this pixel color is imposible to represent in the histogram color space, and can arise from poorly set gamut mapping or saturation settings,
 : - _full gamut_: Shows the combination of the 3 previous options. This is the default mode from darktable 3.4 onwards, and it gives the most complete indication of potentially problematic pixels.
 
 color scheme

--- a/content/module-reference/utility-modules/darkroom/global-color-picker.md
+++ b/content/module-reference/utility-modules/darkroom/global-color-picker.md
@@ -10,7 +10,9 @@ Take color samples from the current darkroom image, display their values in mult
 
 The color picker is activated by pressing the color picker icon. The module's parameters will remain in effect until you leave the darkroom mode.
 
-Besides the global color picker described here, many darktable modules (e.g. [_tone curve_](../../processing-modules/tone-curve.md)) also contain local color pickers which are used to set individual module parameters. You should be aware that these two forms of color picker do not always work in the same color space. The global color picker works in monitor color space and takes its samples after the complete pixelpipe has been processed. Local color pickers run in the color space of the module in which they are activated and reflect the input or output data of that module within the pixelpipe.
+Besides the global color picker described here, many darktable modules (e.g. [_tone curve_](../../processing-modules/tone-curve.md)) also contain local color pickers which are used to set individual module parameters. You should be aware that these two forms of color picker do not always work in the same color space. The global color picker works in the histogram color space and takes its samples after the complete pixelpipe has been processed. Local color pickers run in the color space of the module in which they are activated and reflect the input or output data of that module within the pixelpipe.
+
+As the global color picker runs at the end of the preview pixelpipe, it receives data in display color space then converts it to histogram color space. If you are using a display color space which is not "well behaved" (this is common for a device profile), then colors which are outside of the gamut of the display profile will clip or distort.
 
 # module controls
 

--- a/content/module-reference/utility-modules/shared/histogram.md
+++ b/content/module-reference/utility-modules/shared/histogram.md
@@ -56,6 +56,6 @@ Scrolling in the appropriate area -- rather than dragging -- will also adjust ex
 
 # histogram profile
 
-For the regular histogram, the image data is converted to the _histogram profile_ before the histogram is calculated. You can choose this profile by right-clicking on the [soft-proof](../darkroom/soft-proof.md) or [gamut check](../darkroom/gamut.md) icons in the bottom panel and then selecting the profile of interest.  
+The image data is converted to the _histogram profile_ before the histogram is calculated. You can choose this profile by right-clicking on the [soft-proof](../darkroom/soft-proof.md) or [gamut check](../darkroom/gamut.md) icons in the bottom panel and then selecting the profile of interest.
 
-In the case of the waveform and RGB parade scopes, the colorspace depends on the [preferences > lighttable > color manage cached thumbnails](../../../preferences-settings/lighttable.md) configuration parameter. In its default (true) setting, these scopes are calculated in the “Adobe RGB (compatible)” colorspace. Otherwise, they are calculated in the display colorspace.
+As the histogram runs at the end of the preview pixelpipe, it receives data in display color space. If you are using a display color space which is not "well behaved" (this is common for a device profile), then colors which are outside of the gamut of the display profile may be clipped or distorted.


### PR DESCRIPTION
The global color picker entry was out of date. At least as of v3.4 it works in histogram profile, not display.

The histogram entry incorrectly stated that waveform and RGB parade occur in Adobe RGB or display profile. At least as of v3.4 they work in histogram profile.

The clipping warning is calculated in histogram color space, not output color space, at least as of v3.4.

Also clarify that, as these readouts receive data in display colorspace, they may lose some data in the conversion to histogram profile.

Note there's some inconsistency in terminology ("histogram color space" vs. "histogram profile") between the entries. I haven't corrected this, just kept each one internally consistent.

See darktable-org/darktable#3271 for discussion of this.