### PR TITLE
Update description to explain why module is called surface-blur.

### DIFF
--- a/content/module-reference/processing-modules/surface-blur.md
+++ b/content/module-reference/processing-modules/surface-blur.md
@@ -7,11 +7,11 @@ working-color-space: RGB
 masking: true
 ---
 
-Denoise high ISO images. 
+This module provides smoothing of the surfaces in an image while preversing sharp edges by means of a bilateral filter. It can be used as a type of denoising filter, however bilateral filtering is susceptible to overshoots, and darktable offers better options for denoising. For example, the [_astrophoto denoise_](./astrophoto-denoise.md) module uses a non-local means denoising algorithm, and the [_denoise (profiled)_](./denoise-profiled.md) module provides a choice between non-local means and wavelet denoising algorithms.
 
-This module reduces noise in the image while preserving sharp edges. This is accomplished by averaging pixels with their neighbors, taking into account not only their geometric distance but also their distance on the range scale (i.e. differences in the RGB values).  This module is particularly effective if one RGB channel is more noisy than the others. In such a case, use the [_color calibration_](./color-calibration.md) module to examine the channels one by one, in order to set the blur intensities accordingly.
+This module blurs noise within the surfaces of an image by averaging pixels with their neighbors, taking into account not only their geometric distance but also their distance on the range scale (i.e. differences in the RGB values). It can be particularly useful if one RGB channel is more noisy/needs more smoothing than the others. In such a case, use the [_color calibration_](./color-calibration.md) module to examine the channels one by one, in order to set the blur intensities accordingly. It can be used as a creative filter to provide interesting effects such as lending an image a cartoon-like appearance. When used with chrominance blending, it can also be used to even out the color of a surface (for example, to remove skin redness).
 
-As denoising is a resource-intensive process, it slows down pixelpipe processing significantly. Consider activating this module late in your workflow.
+As this module is a resource-intensive process, it slows down pixelpipe processing significantly. Consider activating this module late in your workflow.
 
 # module controls
 


### PR DESCRIPTION
There were some grumblings on the mail lists why this module was renamed, update the description to better describe the recommended use cases for this module.