### PR TITLE
Add an optional page Table of Contents for longer pages.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -32,12 +32,16 @@ languages:
   pl:
     title: darktable 3.5 (dev) user manual
     languageName: Polish
-    weight: 9    
+    weight: 9
 theme:
   - hugo-darktable-docs-theme
 markup:
   highlight:
     style: algol_nu
+  tableOfContents:
+    endLevel: 3
+    ordered: false
+    startLevel: 1
 outputs:
   home:
     - HTML

--- a/content/module-reference/processing-modules/color-calibration.md
+++ b/content/module-reference/processing-modules/color-calibration.md
@@ -6,6 +6,7 @@ tags:
 working-color-space: RGB
 view: darkroom
 masking: true
+include_toc: true
 ---
 
 A fully-featured color-space correction, white balance adjustment and channel mixer. This simple yet powerful module can be used in the following ways:
@@ -235,7 +236,7 @@ normalize channels
 
 # extracting settings using a color checker
 
-Since the channel mixer is essentially an RGB matrix (similar to the [_input color profile_](./input-color-profile.md) used for RAW images) it can be used to improve the color accuracy of the input color profile by computing ad-hoc color calibration settings. 
+Since the channel mixer is essentially an RGB matrix (similar to the [_input color profile_](./input-color-profile.md) used for RAW images) it can be used to improve the color accuracy of the input color profile by computing ad-hoc color calibration settings.
 
 These computed settings aim to minimize the color difference between the scene reference and the camera recording in a given lighting situation. This is equivalent to creating a generic ICC color profile but here, the profile is instead stored as module settings that can be saved as presets or styles, to be shared and re-used between images. Such profiles are meant to complement and refine the generic input profile but do not replace it.
 
@@ -300,7 +301,7 @@ Use the following process to create your profile preset/style:
 
 ## reading the profile report
 
-The profile report helps you to assess the quality of the calibration. The settings in color calibration are only a "best fit" optimization and will never be 100% accurate for the whole color spectrum. We therefore need to track "how inaccurate" it is in order to know whether we can trust this profile or not. 
+The profile report helps you to assess the quality of the calibration. The settings in color calibration are only a "best fit" optimization and will never be 100% accurate for the whole color spectrum. We therefore need to track "how inaccurate" it is in order to know whether we can trust this profile or not.
 
 Bad profiles can happen and will do more harm than good if used.
 

--- a/content/module-reference/processing-modules/filmic-rgb.md
+++ b/content/module-reference/processing-modules/filmic-rgb.md
@@ -6,6 +6,7 @@ tags:
 working-color-space: RGB
 view: darkroom
 masking: true
+include_toc: true
 ---
 Remap the tonal range of an image by reproducing the tone and color response of classic film.  This module can be used either to expand or to contract the dynamic range of the scene into the dynamic range of the display.
 
@@ -261,7 +262,7 @@ auto-adjust hardness
 : By default, this setting is enabled, and _filmic rgb_ will automatically calculate the power function (aka "gamma") to be applied on the output transfer curve. If this setting is disabled, a _hardness_ slider will appear on the _look_ tab so that value can be manually set.
 
 iterations of high-quality reconstruction
-: Use this setting to increase the number of passes of the _filmic rgb_ highlight reconstruction algorithm. More iterations means more color propagation into clipped areas from pixels in the surrounding neighbourhood. This can produce more neutral highlights, but it also costs more in terms of processing power. It can be useful in difficult cases where there are magenta highlights due to channel clipping. 
+: Use this setting to increase the number of passes of the _filmic rgb_ highlight reconstruction algorithm. More iterations means more color propagation into clipped areas from pixels in the surrounding neighbourhood. This can produce more neutral highlights, but it also costs more in terms of processing power. It can be useful in difficult cases where there are magenta highlights due to channel clipping.
 
 : The default reconstruction works on separate RGB channels and has only one iteration applied, whereas the _high quality_ reconstruction uses a different algorithm that works on RGB ratios (which is a way of breaking down chromaticity from luminance) and can use several iterations to graduately propagate colors from neighbouring pixels in clipped areas. However, if too many iterations are used, the reconstruction can denegenerate, which will result in far colors being improperly inpainted into clipped objects (color bleeding), such as white clouds being inpainted with blue sky, or the sun disc shot through trees being inpainted with leaf green.
 


### PR DESCRIPTION
Add include_toc: true to include the Table of Contents on the page.

Fixes #210.