### PR TITLE
lens correction: warn the user about potential artefacts at borders

### DIFF
--- a/content/module-reference/processing-modules/lens-correction.md
+++ b/content/module-reference/processing-modules/lens-correction.md
@@ -56,4 +56,6 @@ corrections done
 
 **Note:** TCA corrections will not be applied to images that have been identified as monochrome (see [developing monochrome images](../../guides-tutorials/monochrome.md) for more information).
 
+**Note:** Module will fill missing data at borders by repeating the borders' pixels. For strong corrections, this filling can be visible (especially on noisy images). Crop the image if necessary.
+
 ---


### PR DESCRIPTION
Currently, unknown pixels at borders are filled with border pixels (previously they were black) to avoid impacting the algorithms later in the pipe that blur the image.
As pointed out in https://github.com/darktable-org/darktable/issues/9090 and in the original PR https://github.com/darktable-org/darktable/pull/8873 it may give some artefacts. As a solution for now, warn the user about these artefacts in the documentation.
Long term solution will probably be to have an autocrop setting in lens correction, but this probably won't land for 3.6