### PR TITLE
Use american spelling

### DIFF
--- a/content/module-reference/utility-modules/map/locations.md
+++ b/content/module-reference/utility-modules/map/locations.md
@@ -28,7 +28,7 @@ show all
 ## actions on the locations list
 
 click
-: Select or de-select a location. If the location is not currently visible on the map, the map is automatically centred on that location.
+: Select or de-select a location. If the location is not currently visible on the map, the map is automatically centered on that location.
 
 Ctrl+click
 : Edit the name of the location. Press Enter to save changes or Esc to close the editing window without saving.


### PR DESCRIPTION
As dtdocs use American spelling I change this word to be in conformity with the rest of the docs.

https://www.grammarly.com/blog/center-centre/
