### PR TITLE
Thumb color management pref is hidden now

### DIFF
--- a/content/lighttable/digital-asset-management/thumbnails.md
+++ b/content/lighttable/digital-asset-management/thumbnails.md
@@ -24,7 +24,7 @@ Thumbnails are never removed from the secondary cache. You can manually clean th
 
 If you choose not to activate the disk backend and select too small a cache size, darktable may become unresponsive, you may experience continuous regeneration of thumbnails when you navigate your collection or flickering of thumbnail images. A good choice of cache size is 512MB or higher (see [memory](../../../special-topics/memory.md) for more information).
 
-All thumbnails are fully color managed if the corresponding option is activated in [preferences > lighttable > thumbnails](../../../preferences-settings/lighttable.md#thumbnails). Colors are rendered accurately on screen as long as your system is properly set up to hand over the right monitor profile to darktable. For more information see the [color management](../../../special-topics/color-management/_index.md) section.
+All thumbnails are fully color managed. Colors are rendered accurately on screen as long as your system is properly set up to hand over the right monitor profile to darktable. For more information see the [color management](../../../special-topics/color-management/_index.md) section.
 
 # skulls
 


### PR DESCRIPTION
The option to control thumbs color management specified in the docs text is hidden by commit darktable-org/darktable@2167dcdd (and set true by default). The corresponding code is not deleted, which means that you can disable color management by manually editing the dt configuration file. However, there should be no need for this, as enabling this option in practice does not increase the execution time. Given this, it is enough to just write that thumbnails are color managed...