### PR TITLE
Use exactly the same terms as in the dt interface

### DIFF
--- a/content/lighttable/digital-asset-management/grouping.md
+++ b/content/lighttable/digital-asset-management/grouping.md
@@ -12,15 +12,15 @@ You can combine images into a group by selecting them and clicking the “group�
 
 Images that are members of a group are denoted by a group icon ![top panel_grouping icon](./grouping/top-panel_grouping.png#icon) in their thumbnails.
 
-This icon also appears as a button, in the top panel of the lighttable view, that can be used to toggle grouping on and off. If grouping is off, all images are displayed as individual thumbnails. If grouping is on, the images in a group are represented by a single thumbnail image (the group head). If you press the group icon in the group head's thumbnail, that group is expanded (click a second time to collapse). If you then expand another group, the first group collapses. 
+This icon also appears as a button, in the top panel of the lighttable view, that can be used to toggle grouping on and off. If grouping is off, all images are displayed as individual thumbnails. If grouping is on, the images in a group are represented by a single thumbnail image (the group leader). If you press the group icon in the group leader's thumbnail, that group is expanded (click a second time to collapse). If you then expand another group, the first group collapses. 
 
 An expanded group in the filemanager mode of lighttable view is indicated by an orange frame that appears as soon as your mouse pointer hovers over one of the images. This frame surrounds all images in the group.
 
-You can define which image is considered to be the group head by clicking on the group icon of the desired image while that group is expanded. The group icon is shown only if grouping mode is enabled, so to change the group head, you need to first enable grouping, expand the appropriate group and finally click the group icon of the desired "group head" image. The current group head is shown in a tooltip when you hover over the group icon of an image.
+You can define which image is considered to be the group leader by clicking on the group icon of the desired image while that group is expanded. The group icon is shown only if grouping mode is enabled, so to change the group leader, you need to first enable grouping, expand the appropriate group and finally click the group icon of the desired "group leader" image. The current group leader is shown in a tooltip when you hover over the group icon of an image.
 
-If you collapse an image group and then enter darkroom mode (e.g. by double-clicking on the thumbnail), the group head image will be opened for developing.
+If you collapse an image group and then enter darkroom mode (e.g. by double-clicking on the thumbnail), the group leader image will be opened for developing.
 
-Image groups are also a convenient way to protect an existing history stack against unintentional changes. If you have just finalized an image and want to protect its current version, simply select the image, click “duplicate” in the selected images panel, and make sure that grouping is switched on and that the group is collapsed. Now, whenever you open the image group again in the darkroom, only the group head will be altered. The underlying duplicate will remain unchanged.
+Image groups are also a convenient way to protect an existing history stack against unintentional changes. If you have just finalized an image and want to protect its current version, simply select the image, click “duplicate” in the selected images panel, and make sure that grouping is switched on and that the group is collapsed. Now, whenever you open the image group again in the darkroom, only the group leader will be altered. The underlying duplicate will remain unchanged.
 
 ---
 


### PR DESCRIPTION
While the group head is perfectly understandable term it's better to use exactly the same terms as in the dt interface.