### PR TITLE
Fix description of duplicate-manager module

### DIFF
--- a/content/module-reference/utility-modules/darkroom/duplicate-manager.md
+++ b/content/module-reference/utility-modules/darkroom/duplicate-manager.md
@@ -1,15 +1,15 @@
 ---
 title: duplicate manager
 id: duplicate-manager
-applicable-version: 3.2.1
+applicable-version: 3.6
 tags: 
 view: darkroom
 ---
 
-View and create duplicates of the current image.
+View and create multiple versions of the current image. Each version of the image can be edited independently without affecting the versions. When creating multiple versions of an image, the versions will all be based on the same raw image file, but the editing history of each version is stored in a its own separate XMP sidecar file. 
 
 The duplicate manager lists all versions of the current darkroom image with their preview thumbnails. Hold down the left mouse button on a thumbnail to temporarily show that version in the center view. Double click to switch to this version and edit it. 
 
-The buttons on the top-right allow you to create new duplicates of the current image. You can either create a 'virgin' version (with an empty history stack) or an exact duplicate of the current image. For your convenience, you can also assign a name to each version.
+The buttons at the bottom of the module allow you to create new duplicates of the current image. You can either create a 'virgin' version (with an empty history stack) or an exact duplicate of the current image.
 
-The displayed name is stored in the _version name_ metadata tag, which can also be edited within the [metadata editor](../shared/metadata-editor.md) module.
+To the right of each thumbnail there is a version number displayed. By clicking in the area below the version number, a version name can be entered against that version of the image, which can be a helpful reminder of the version's purpose. This name is stored in the _version name_ metadata tag, which can also be edited within the [metadata editor](../shared/metadata-editor.md) module in the lighttable view.


### PR DESCRIPTION
duplicate manager module talked about buttons in the wrong place, and wasn't very clear as to how version names are created.