### PR TITLE
specify which selected images are exported

### DIFF
--- a/content/module-reference/utility-modules/shared/export.md
+++ b/content/module-reference/utility-modules/shared/export.md
@@ -92,7 +92,7 @@ mode
 : When applying a style during export this option defines whether the history stack items of that style replace the original history stack of the image or are appended to it. Technically speaking, in append mode history stack items of the style will constitute separate instances of the respective modules on top of any existing ones (see also [multiple instances](../../../darkroom/processing-modules/multiple-instances.md)). As a consequence the original history stack will remain in effect with the new items being applied in addition. This way you can apply an overall adjustment (e.g. exposure) to a number of exported images while respecting the settings of each individual image.
 
 export
-: Press this button to start a background job to export all selected images. A bar at the bottom of the left hand panel displays the progress of the export job. Furthermore a notification message pops up reporting the completion of each individual export. You may click on the pop-up to make it disappear. You may abort the export job by clicking on the "x" icon located close to the progress bar.
+: Press this button to start a background job to export all selected and visible images. A bar at the bottom of the left hand panel displays the progress of the export job. Furthermore a notification message pops up reporting the completion of each individual export. You may click on the pop-up to make it disappear. You may abort the export job by clicking on the "x" icon located close to the progress bar.
 
 # metadata preferences
 


### PR DESCRIPTION
Related to discussion on dt issue [#10032](https://github.com/darktable-org/darktable/issues/10032)
Just not to forget.
Other possibility: "not collapsed selected images", but you know better than me what would be fine.