### PR TITLE
Fix an inaccuracy in the default export directory

### DIFF
--- a/content/overview/workflow/export.md
+++ b/content/overview/workflow/export.md
@@ -12,7 +12,7 @@ darktable is a non-destructive editor, which means that all changes are recorded
 
    The export module offers many options, but by far the most common use is to “save a developed raw image as a JPEG”. You can either export the currently-edited image directly from the darkroom view or select one or more images from the lighttable view and export them all at once. 
 
-2. Select which images to export (if you are in the lighttable view), open the export module, set _target storage_ to "file on disk" and select a location to save your images -- by default, they will be exported to a "darktable" directory within the directory that contains your Raw file(s). Choose a "file format" of JPEG and keep the default settings. 
+2. Select which images to export (if you are in the lighttable view), open the export module, set _target storage_ to "file on disk" and select a location to save your images -- by default, they will be exported to a "darktable_exported" directory within the directory that contains your Raw file(s). Choose a "file format" of JPEG and keep the default settings. 
 
 3. Click the "export" button to save your processed images in the selected location.
 


### PR DESCRIPTION
It is `darktable_exported`, not `darktable`.
