### PR TITLE
Replace the word with a more commonly used one

### DIFF
--- a/content/module-reference/processing-modules/bloom.md
+++ b/content/module-reference/processing-modules/bloom.md
@@ -21,7 +21,7 @@ _**Note:** This module performs blurs in Lab color space, and is no longer recom
 # module controls
 
 size
-: The spacial extent of the bloom effect.
+: The spatial extent of the bloom effect.
 
 threshold
 : The threshold for the brightness increase.

--- a/content/module-reference/processing-modules/surface-blur.md
+++ b/content/module-reference/processing-modules/surface-blur.md
@@ -20,7 +20,7 @@ This module is resource-intensive and slows down pixelpipe processing significan
 # module controls
 
 radius
-: The spacial extent of the gaussian blur.
+: The spatial extent of the gaussian blur.
 
 red, green, blue
 : The blur intensity for each of the RGB channels.

--- a/content/module-reference/utility-modules/shared/scopes.md
+++ b/content/module-reference/utility-modules/shared/scopes.md
@@ -34,7 +34,7 @@ The three rightmost colored buttons toggle the display of the red, green and blu
 
 ![waveform scope (horizontal)](./scopes/waveform.png#w50)
 
-The waveform scope shows similar data to the histogram, but allows you to view that data in a spacial context.
+The waveform scope shows similar data to the histogram, but allows you to view that data in a spatial context.
 
 In the "standard" horizontal waveform, the x-axis of the waveform represents the x-axis of the image -- the right-hand side of the waveform represents the right-hand side of the image and the left-hand side of the waveform represents the left-hand side of the image.
 


### PR DESCRIPTION
This is not a typo fix or switching to American spelling, but a purely stylistic change.

Major English dictionaries lists spatial as the preferred word and spacial as the less commonly used alternative (M-W) or spelling variant (Collins).

I do not want to say that spacial is invalid word, but Google Ngram shows that the word 'spacial' is used many orders of magnitude less frequently:
https://books.google.com/ngrams/graph?content=spacial%2Cspatial&year_start=1800&year_end=2019&corpus=26&smoothing=3
