### PR TITLE
Fix local test website default URL (in README.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Building the site to test locally can be done from the root of the repo.
 $ hugo server -D --disableFastRender
 ```
 
-The site should then be available at http://localhost:1313/dtdocs/
+The site should then be available at http://localhost:1313/usermanual/development/ (you can see the URL in the output of the `hugo server` command).
 
 ## Production Website
 


### PR DESCRIPTION
The path component of the URL is defined in baseURL parameter in config.yaml and recently this component was changed to /usermanual/development/
