### PR TITLE
A pixel cannot have an edge

### DIFF
--- a/content/module-reference/processing-modules/defringe.md
+++ b/content/module-reference/processing-modules/defringe.md
@@ -31,4 +31,4 @@ edge detection radius
 : The algorithm uses the difference between the input image and a gaussian-blurred version of the same image to detect edges. This parameter controls the spatial extent of the gaussian blur used in the edge detection. Try increasing this value if you want a stronger detection of the fringes or the thickness of the fringe edges is too high.
 
 threshold
-: The threshold over which the edge of a pixel is counted as a “fringe”. Try lowering this value if there is not enough fringe detected and increasing it if too many pixels are desaturated.
+: The threshold over which a pixel is counted as a “fringe”. Try lowering this value if there is not enough fringe detected and increasing it if too many pixels are desaturated.


### PR DESCRIPTION
This is probably a mistake. A pixel is the smallest, "atomic" element of an image, it cannot have an edge.