### PR TITLE
Correct one typo and one factual error

### DIFF
--- a/content/special-topics/mem-performance.md
+++ b/content/special-topics/mem-performance.md
@@ -132,7 +132,7 @@ g. asynchronous mode
 
 h. disable device
 : _0 = enable device; 1 = disable device_
-: If darktable detects a malfunctioning device it will automatically mark it as such by setting this value to 1. If you have a device that reports a lot of errors you can manually disable it be setting this field to 0.
+: If darktable detects a malfunctioning device it will automatically mark it as such by setting this parameter to 1. If you have a device that reports a lot of errors you can manually disable it by setting this to 1.
 
 i. benchmark
 : When darktable detects a new device on your system it will do a small benchmark and store the result here. You can change this back to 0 to force darktable to redo the benchmark but in most cases **you should not edit this setting**.


### PR DESCRIPTION
This commit fixes one typo ("be" instead of "by") and one factual error: the opposite value, not the specified one, is correct.

Also "set value to 1" is not an accurate wording as here "1" is the value, so it's better to write "set parameter" (or field, or setting as other options).