### PR TITLE
Typo ans style fixes

### DIFF
--- a/content/special-topics/program-invocation/darktable-cli.md
+++ b/content/special-topics/program-invocation/darktable-cli.md
@@ -234,9 +234,9 @@ No options provided.
 `hint`
 : The preferred way to manage the compression
 :  - `0`: default
-:  - `1`: picture : digital picture, like portrait, inner shot
-:  - `2`: photo   : outdoor photograph, with natural lighting
-:  - `3`: graphics: discrete tone image (graph, map-tile etc)
+:  - `1`: picture: digital picture, like portrait, inner shot
+:  - `2`: photo: outdoor photograph, with natural lighting
+:  - `3`: graphic: discrete tone image (graph, map-tile etc)
 
 ### copy
 


### PR DESCRIPTION
The name of the option is 'graphic', not 'graphics'.

Also, there is no point in aligning the colons. They will only be aligned when viewed in a fixed-width font environment, this will not be the case in a browser window.
