### PR TITLE
Correct language name with ñ

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -20,7 +20,7 @@ languages:
     weight: 5
   es:
     title: darktable 4.2 user manual
-    languageName: Espanol
+    languageName: Español
     weight: 6
   gl:
     title: darktable 4.2 user manual


### PR DESCRIPTION
Español instead Espanol on config.yaml