### PR TITLE
Mention git in the lua scripts installer docs, add a link to the documentation of the scripts.

### DIFF
--- a/content/module-reference/utility-modules/lighttable/lua-scripts-installer.md
+++ b/content/module-reference/utility-modules/lighttable/lua-scripts-installer.md
@@ -6,6 +6,10 @@ tags:
 view: lighttable
 ---
 
-This module provides an interface for installing darktable [lua scripts](../../../lua/_index.md). The first time it is run, instructions are displayed in the module.
+As described in [lua scripts](../../../lua/_index.md), darktable provides powerful scripting capabilities to extend its functionality. Many such scripts are already available. The Lua script installer module helps to install them without the need for manual configuration. The first time it is run, instructions are displayed in the module.
 
-It can be disabled with an option in [preferences > lua options](../../../preferences-settings/lua-options.md).
+For the module to be able to install the scripts, you will need to have git installed and available on your path. You can get it from [git-scm.com](https://git-scm.com/).
+
+The officially supported scripts are documented [here](https://docs.darktable.org/lua/stable/lua.scripts.manual/scripts/).
+
+The module can be disabled with an option in [preferences > lua options](../../../preferences-settings/lua-options.md).

--- a/content/module-reference/utility-modules/lighttable/lua-scripts-installer.md
+++ b/content/module-reference/utility-modules/lighttable/lua-scripts-installer.md
@@ -6,7 +6,7 @@ tags:
 view: lighttable
 ---
 
-As described in [lua scripts](../../../lua/_index.md), darktable provides powerful scripting capabilities to extend its functionality. Many such scripts are already available. The Lua script installer module helps to install them without the need for manual configuration. The first time it is run, instructions are displayed in the module.
+As described in [lua scripts](../../../lua/_index.md), darktable provides powerful scripting capabilities to extend its functionality and integrate with other software. Many such scripts are already available. The Lua script installer module helps to install them without the need for manual configuration. The first time it is run, instructions are displayed in the module.
 
 For the module to be able to install the scripts, you will need to have git installed and available on your path. You can get it from [git-scm.com](https://git-scm.com/).
 


### PR DESCRIPTION
- Users often do not know what scripts are available, so I added a link.
- The need to have git installed was only mentioned in the docs of the script manager (https://docs.darktable.org/lua/stable/lua.scripts.manual/scripts/tools/script_manager/#additional-software-required - and even there, the link is wrong -> I've opened a separate PR for that).