### PR TITLE
Add note about conflicting TCA corrections.

### DIFF
--- a/content/module-reference/processing-modules/lens-correction.md
+++ b/content/module-reference/processing-modules/lens-correction.md
@@ -12,6 +12,8 @@ Automatically correct for (or simulate) lens distortion, transverse chromatic ab
 
 You can choose to either use lens correction data embedded in your Raw file (where present/supported) or correction data provided by the external [lensfun library](https://lensfun.github.io/).
 
+If TCA correction is enabled in this module, then [_raw chromatic aberrations_](./raw-chromatic-aberrations.md) should not also be enabled, as it will conflict. [_chromatic aberrations_](./chromatic-aberrations.md) may be used to correct any TCA that remains after this module's correction is applied.
+
 # lensfun correction data
 
 If your system's lensfun library has no correction profile for the automatically identified camera/lens combination, the controls for the three photometric parameters (below) are replaced with a warning message. You may try to find the right profile yourself by searching for it in the menu. 

--- a/content/module-reference/processing-modules/lens-correction.md
+++ b/content/module-reference/processing-modules/lens-correction.md
@@ -12,8 +12,7 @@ Automatically correct for (or simulate) lens distortion, transverse chromatic ab
 
 You can choose to either use lens correction data embedded in your Raw file (where present/supported) or correction data provided by the external [lensfun library](https://lensfun.github.io/).
 
-If TCA correction is enabled in this module, then [_raw chromatic aberrations_](./raw-chromatic-aberrations.md) should not also be enabled, as it will conflict. [_chromatic aberrations_](./chromatic-aberrations.md) may be used to correct any TCA that remains after this module's correction is applied.
-
+If TCA correction is enabled in this module, also using [_raw chromatic aberrations_](./raw-chromatic-aberrations.md) may cause aritifacts from overcorrection. 
 # lensfun correction data
 
 If your system's lensfun library has no correction profile for the automatically identified camera/lens combination, the controls for the three photometric parameters (below) are replaced with a warning message. You may try to find the right profile yourself by searching for it in the menu. 

--- a/content/module-reference/processing-modules/raw-chromatic-aberrations.md
+++ b/content/module-reference/processing-modules/raw-chromatic-aberrations.md
@@ -14,6 +14,8 @@ This module currently only works for raw images recorded with a Bayer sensor (th
 
 The module will also not apply any corrections to any photos that have been identified as monochrome (see [developing monochrome images](../../guides-tutorials/monochrome.md) for more information).
 
+If this module is enabled, then TCA correction in [_lens correction_](./lens-correction.md) should not also be enabled, as it will conflict.
+
 # module controls
 
 iterations


### PR DESCRIPTION

raw chromatic aberrations shifts pixels based on observed TCA in the image content, and then if it's also enabled, lens correction shifts pixels further based on a fixed model, resulting in an over-correction.