### PR TITLE
Add Apple keychain and Windows Credentials for security/pwstorage

### DIFF
--- a/content/preferences-settings/security.md
+++ b/content/preferences-settings/security.md
@@ -45,7 +45,7 @@ ask before exporting in overwrite mode
 # other
 
 password storage backend to use
-: The backend to use for password storage. Options: “auto” (default), “none”, “libsecret”, “kwallet”. 
+: The backend to use for password storage. Options: “auto” (default), “none”, “libsecret”, “kwallet”, "Apple keychain" (on macOS). 
 
 executable for playing audio files
 : Define an external program which is used in the lighttable view to play audio files that some cameras record to keep notes for images (default “aplay”). 

--- a/content/preferences-settings/security.md
+++ b/content/preferences-settings/security.md
@@ -45,7 +45,7 @@ ask before exporting in overwrite mode
 # other
 
 password storage backend to use
-: The backend to use for password storage. Options: “auto” (default), “none”, “libsecret”, “kwallet”, "apple_keychain" (on macOS). 
+: The backend to use for password storage. Options: “auto” (default), “none”, “libsecret”, “kwallet”, "apple_keychain" (on macOS), "windows_credentials" (on Windows). 
 
 executable for playing audio files
 : Define an external program which is used in the lighttable view to play audio files that some cameras record to keep notes for images (default “aplay”). 

--- a/content/preferences-settings/security.md
+++ b/content/preferences-settings/security.md
@@ -45,7 +45,7 @@ ask before exporting in overwrite mode
 # other
 
 password storage backend to use
-: The backend to use for password storage. Options: “auto” (default), “none”, “libsecret”, “kwallet”, "Apple keychain" (on macOS). 
+: The backend to use for password storage. Options: “auto” (default), “none”, “libsecret”, “kwallet”, "apple_keychain" (on macOS). 
 
 executable for playing audio files
 : Define an external program which is used in the lighttable view to play audio files that some cameras record to keep notes for images (default “aplay”). 


### PR DESCRIPTION
With darktable PR [#16016](https://github.com/darktable-org/darktable/pull/16016) we now have the Apple keychain backend for password storage.