### PR TITLE
Clipping threshold control for auto-exposure has been removed from the exposure module

### DIFF
--- a/content/module-reference/processing-modules/exposure.md
+++ b/content/module-reference/processing-modules/exposure.md
@@ -13,7 +13,7 @@ Increase or decrease the overall brightness of an image.
 This module has two modes of operation:
 
 manual
-: Set the _exposure_, _black level_ and _clipping threshold_ manually
+: Set the _exposure_ and _black level_ manually
 
 automatic (RAW images only)
 : Use an analysis of the image's histogram to automatically set the exposure. Darktable automatically selects the exposure compensation that is required to shift the selected _percentile_ to the selected _target level_ (see definitions below). This mode is particularly useful for automatically altering a large number of images to have the same exposure. A typical use case of automatic mode is deflickering of time-lapse photographs.
@@ -29,9 +29,6 @@ compensate camera exposure (manual mode)
 exposure (manual mode)
 : Increase (move to the right) or decrease (move to the left) the exposure value (EV). To adjust by more than the default limits shown on the slider, right click and enter the desired value up to +/-18 EV (see [module controls](../../darkroom/processing-modules/module-controls.md)).
 : The color picker tool on the right sets the exposure such that the average of the selected region matches the target lightness defined in [area exposure mapping](#area-exposure-mapping) options.
-
-clipping threshold (manual mode)
-: Define what percentage of bright values are to be clipped in the calculation of the _exposure_ and _black level correction_. Use the color picker to sample a portion of the image to be used for this calculation.
 
 percentile (automatic mode)
 : Define a location in the histogram to use for automatic exposure correction. A percentile of 50% denotes a position in the histogram where 50% of pixel values are above and 50% of pixel values are below that exposure.


### PR DESCRIPTION
This module control was removed in https://github.com/darktable-org/darktable/commit/87089d17fed8db8311d2ec25b44d69918f72feb0