### PR TITLE
Factual and grammatical corrections to the description of metadata applying parameters during import

### DIFF
--- a/content/module-reference/utility-modules/lighttable/import.md
+++ b/content/module-reference/utility-modules/lighttable/import.md
@@ -56,7 +56,7 @@ metadata
 
 : Double-click on a label to reset the corresponding field. Double-click on the "metadata presets" label to reset all fields.
 
-: When [preferences > storage > write sidecar file for each image](../../../preferences-settings/storage.md#xmp) is unchecked an additional column "from xmp" is presented so that you can choose to prevent the import of metadata from XMP files.
+: If [preferences > storage > create XMP files](../../../preferences-settings/storage.md#xmp-sidecar-files) is set to "never", an additional column "from XMP" is presented so that you can choose to prevent the import of metadata from XMP files.
 
 tags
 : If you want to add further tags by default when importing images, you can provide them here as a comma separated list. As with metadata you can also choose from any presets saved within the [tagging](../shared/tagging.md) module.


### PR DESCRIPTION
Darktable changes to be reflected here:
- the new preferences section title (this causes a change in the link anchor on the dtdocs page)
- the new name of the preference and its value, which leads to the appearance of an additional column
- the column label now has the corrected XMP spelling

Grammatical corrections:

- after a dependent introductory clause, we use a comma to separate the introductory clause from the main clause
- we don't use "when" to represent only possible but not certain situations
