### PR TITLE
Only expanding a module can cause it to scroll to the top

### DIFF
--- a/content/preferences-settings/darkroom.md
+++ b/content/preferences-settings/darkroom.md
@@ -53,8 +53,8 @@ only collapse modules in current group
 expand the module when it is activated, and collapse it when disabled
 : Select this option for the darkroom to automatically expand or collapse [processing modules](../module-reference/processing-modules) when they are enabled or disabled. (default off)
 
-scroll processing modules to the top when expanded/collapsed
-: With this option enabled [processing modules](../module-reference/processing-modules) are scrolled to the top of the right-hand panel when expanded or collapsed (default on).
+scroll processing modules to the top when expanded
+: With this option enabled [processing modules](../module-reference/processing-modules) are scrolled to the top of the right-hand panel when expanded. (default on)
 
 show right-side buttons in processing module headers
 : Choose whether to show the four buttons (mask indicator, multi-instance menu, reset, presets menu) on the right-hand-side of the [module header](../darkroom/processing-modules/module-header.md) for processing modules. These buttons will always appear when the mouse is over the module. At other times they will be shown or hidden according to this preference selection: 

--- a/content/preferences-settings/lighttable.md
+++ b/content/preferences-settings/lighttable.md
@@ -19,7 +19,7 @@ expand a single utility module at a time
 : Controls how utility modules are expanded. If this option is enabled, expanding a module by clicking collapses any other currently expanded panel. If you want to expand a panel without collapsing the others you can do so with Shift+click. Disabling this option inverts the meaning of click and Shift+click (default off).
 
 scroll utility modules to the top when expanded
-: With this option enabled the side panels will scroll a utility module to the top of the panel when it is expanded or collapsed (default off).
+: With this option enabled the side panels will scroll a utility module to the top of the panel when it is expanded. (default off)
 
 rating an image one star twice will not zero out the rating
 : Normally clicking a one star rating twice will set a zero star rating to that image. Check this option to disable this functionality (default off).


### PR DESCRIPTION
It seems to have worked this way from the beginning, but it was described incorrectly in the program preferences. The description in the preferences has been adjusted to match the actual behavior in https://github.com/darktable-org/darktable/pull/11672.