### PR TITLE
Fix projection type names

### DIFF
--- a/content/module-reference/processing-modules/lens-correction.md
+++ b/content/module-reference/processing-modules/lens-correction.md
@@ -60,7 +60,7 @@ photometric parameters (focal length, aperture, focal distance)
 : You can manually override all automatically selected parameters. Either take one of the predefined values from the drop-down menu or, with the drop-down menu still open, just type in your own value.
 
 geometry
-: In addition to correcting lens flaws, this module can change the projection type of your image. Set this combobox to the desired projection type (e.g. "rectilinear", "fish-eye", "panoramic", "equirectangular", "orthographic", "stereographic", "equisolid angle", "thoby fish-eye").  To correct the aspect ratio of an anamorphic lens, use the [_rotate and perspective_](./rotate-perspective.md) module.
+: In addition to correcting lens flaws, this module can change the projection type of your image. Set this combobox to the desired projection type (e.g. "rectilinear", "fisheye", "panoramic", "equirectangular", "orthographic", "stereographic", "equisolid angle", "Thoby fisheye").  To correct the aspect ratio of an anamorphic lens, use the [_rotate and perspective_](./rotate-perspective.md) module.
 
 scale
 : Adjust the scaling factor of your image to avoid black corners. Press the auto scale button (to the right of the slider) for darktable to automatically find the best fit.


### PR DESCRIPTION
Thoby is a person's last name, so it should not be lowercased (this is fixed in the program, we should reflect it here).

Also, reflected replacement of "fish-eye" with "fisheye", a much more common spelling.