### PR TITLE
Remove incorrect warning in negadoctor manual

### DIFF
--- a/content/module-reference/processing-modules/negadoctor.md
+++ b/content/module-reference/processing-modules/negadoctor.md
@@ -68,7 +68,7 @@ scan exposure bias
 
 This tab contains sliders that allow you to make color cast corrections within both the shadow and highlight regions.
 
-The settings on this tab should not be needed for most well-preserved negatives. It is mostly useful for old and poorly-preserved negatives with a decayed film base that introduces undesirable color casts. Note that the shadows color cast setting will have no effect if the _scan exposure bias_ setting in the [_film properties_](#film-properties) tab is set to a non-zero value.
+The settings on this tab should not be needed for most well-preserved negatives. It is mostly useful for old and poorly-preserved negatives with a decayed film base that introduces undesirable color casts.
 
 The other case where these color cast corrections may be needed is if the white balance properties of the light used to scan the film negative are significantly different to the light source under which the original film camera took the shot. For example, if you illuminate the film with an LED light, but the original shot was taken under daylight, this may require some additional color cast corrections.
 


### PR DESCRIPTION
shadows color cast does indeed have an effect when the scanner exposure bias is non-zero. Perhaps this was different in older DT versions.