### PR TITLE
spelling and grammar fixes for the Overview area in German

### DIFF
--- a/po/content.de.po
+++ b/po/content.de.po
@@ -24355,7 +24355,7 @@ msgid ""
 ": An optional panel that can be enabled at the bottom of the screen to display a timeline (in the lighttable view) or a filmstrip (in other views) of images in the current collection.\n"
 msgstr ""
 "7. Leiste mit [Filmstreifen](../../module-reference/utility-modules/shared/filmstrip.md) oder [Zeitleiste](../../module-reference/utility-modules/lighttable/timeline.md)\n"
-": Eine optionale Leiste, die unten am Bildschirm eingeblendet werden kann. Sie zeigt eine Zeitleiste (in der Ansicht Leuchttisch) oder einen Filmstreifen (in anderen Ansichten) mit Bildern der geöffneten Sammlung.\n"
+": Eine optionale Leiste, die am unteren Bildschirmrand eingeblendet werden kann. Sie zeigt eine Zeitleiste (in der Ansicht Leuchttisch), oder einen Filmstreifen (in anderen Ansichten) mit Bildern der geöffneten Sammlung.\n"
 
 #. type: Title #
 #: content/overview/user-interface/screen-layout.md
@@ -24379,55 +24379,55 @@ msgstr "Jedes Bedienfeld kann durch Anklicken des Dreiecks am Außenrand ein- un
 #: content/overview/user-interface/screen-layout.md
 #, no-wrap
 msgid "`TAB` temporarily expands the centre view to fill the whole window. Press again to return to the previous view.\n"
-msgstr "`TAB`expandiert temporär die Mittenansicht über den gesamten Bildschirm. Ein erneutes Drücken geht wieder zur ursprünglichen Ansicht zurück.\n"
+msgstr "`TAB` expandiert den Mittelteil über den gesamten Bildschirm. Ein erneutes Drücken geht wieder zur ursprünglichen Ansicht zurück.\n"
 
 #. type: Bullet: ' - '
 #: content/overview/user-interface/screen-layout.md
 #, no-wrap
 msgid "`F11` toggles fullscreen mode\n"
-msgstr "`F11`schaltet auf Modus Vollansicht\n"
+msgstr "`F11` wechselt in den Vollbildmodus.\n"
 
 #. type: Bullet: ' - '
 #: content/overview/user-interface/screen-layout.md
 #, no-wrap
 msgid "`Shift+Ctrl+t` toggles the top panel (between the image and the top banner)\n"
-msgstr "`Shift+Ctrl+t`schaltet die obere Leiste um (zwischen Bild und oberem Banner)\n"
+msgstr "`Shift+Ctrl+t` wechselt zwischen verschiedenen Anzeigemodi der oberen Leiste (zwischen Bild und oberem Banner).\n"
 
 #. type: Bullet: ' - '
 #: content/overview/user-interface/screen-layout.md
 #, no-wrap
 msgid "`Shift+Ctrl+b` toggles the bottom panel (between the image and the filmstrip/timeline, if shown)\n"
-msgstr "`Shift+Ctrl+b`schaltet die untere Leiste um (zwischen Bild und Filmstreifen/Zeitachse, falls gezeigt).\n"
+msgstr "`Shift+Ctrl+b` wechselt zwischen verschiedenen Anzeigemodi der unteren Leiste (zwischen Bild und Filmstreifen/Zeitachse, falls gezeigt).\n"
 
 #. type: Bullet: ' - '
 #: content/overview/user-interface/screen-layout.md
 #, no-wrap
 msgid "`Shift+Ctrl+l` toggles the left panel\n"
-msgstr "`Shift+Ctrl+l`schaltet das linke Seitenfenster zu und weg\n"
+msgstr "`Shift+Ctrl+l` blendet die linke Seitenleiste aus und ein.\n"
 
 #. type: Bullet: ' - '
 #: content/overview/user-interface/screen-layout.md
 #, no-wrap
 msgid "`Shift+Ctrl+r` toggles the right panel\n"
-msgstr "`Shift+Ctrl+r`schaltet das rechte Seitenfenster zu und weg\n"
+msgstr "`Shift+Ctrl+r` blendet die rechte Seitenleiste aus und ein.\n"
 
 #. type: Bullet: ' - '
 #: content/overview/user-interface/screen-layout.md
 #, no-wrap
 msgid "`Ctrl+f` toggles the filmstrip/timeline\n"
-msgstr "`Strg+f` wechselt zwischen Filmstreifen und Zeitleiste\n"
+msgstr "`Strg+f` blendet die untere Filmstreifen-/Zeitleisteleiste aus und ein.\n"
 
 #. type: Bullet: ' - '
 #: content/overview/user-interface/screen-layout.md
 #, no-wrap
 msgid "`Ctrl+h` toggles the top banner\n"
-msgstr "`Ctrl+h`schaltet das obere Banner zu und weg\n"
+msgstr "`Ctrl+h` blendet das obere Banner aus und ein.\n"
 
 #. type: Bullet: ' - '
 #: content/overview/user-interface/screen-layout.md
 #, no-wrap
 msgid "`b` toggles all borders and panel-collapse controls\n"
-msgstr "`b`schaltet alle Ränder und Fenster-Wegschalt Kontrollen\n"
+msgstr "`b` blendet alle Ränder und die dazugehörigen Kontrollelemente der Leisten aus und ein.\n"
 
 #. type: Plain text
 #: content/overview/user-interface/screen-layout.md
@@ -24518,37 +24518,37 @@ msgstr "Zwischen den einzelnen Ansichten kann oben rechts durch Anklicken des Na
 #: content/overview/user-interface/views.md
 #, no-wrap
 msgid "`L` switches to lighttable\n"
-msgstr "`L`schaltet zur Ansicht Leuchttisch\n"
+msgstr "`L` wechselt zur Ansicht Leuchttisch\n"
 
 #. type: Bullet: ' - '
 #: content/overview/user-interface/views.md
 #, no-wrap
 msgid "`D` switches to darkroom\n"
-msgstr "mit `D` in die Dunkelkammer wechseln\n"
+msgstr "`D` wechselt zur Ansicht Dunkelkammer\n"
 
 #. type: Bullet: ' - '
 #: content/overview/user-interface/views.md
 #, no-wrap
 msgid "`M` switches to map\n"
-msgstr "`M`schaltet zu Karte\n"
+msgstr "`M` wechselt zur Ansicht Karte\n"
 
 #. type: Bullet: ' - '
 #: content/overview/user-interface/views.md
 #, no-wrap
 msgid "`P` switches to print\n"
-msgstr "`P` schaltet zu Drucken\n"
+msgstr "`P` wechselt zur Ansicht Drucken\n"
 
 #. type: Bullet: ' - '
 #: content/overview/user-interface/views.md
 #, no-wrap
 msgid "`S` switches to slideshow\n"
-msgstr "`S`schaltet zu Diaschau\n"
+msgstr "`S` wechselt zur Ansicht Diaschau\n"
 
 #. type: Bullet: ' - '
 #: content/overview/user-interface/views.md
 #, no-wrap
 msgid "`T` switches to tethering\n"
-msgstr "`T`schaltet zu Tethering\n"
+msgstr "`T` wechselt zur Ansicht Tethering\n"
 
 #. type: Yaml Front Matter Hash Value: title
 #: content/overview/user-interface/_index.md
@@ -24579,8 +24579,8 @@ msgstr "Kopfzeile"
 #, no-wrap
 msgid "The top panel appears in all darktable views and provides access to common functions.\n"
 msgstr ""
-"Die obere Leiste gibt es für alle Ansichten von darktable gemeinsam und "
-"sieht Zugang für normale Funktionen vor.\n"
+"Die obere Leiste gibt es für alle Ansichten von darktable und "
+"bietet Zugang zu gängigen Funktionen.\n"
 
 #. type: Plain text
 #: content/overview/user-interface/top-panel.md
@@ -24601,8 +24601,8 @@ msgid ""
 "filter / sort\n"
 ": Choose how to filter and sort the images. Criteria can be altered in the [collection filters](../../module-reference/utility-modules/shared/collection-filters.md) module or by clicking on the ![top-panel_filter-preferences icon](./top-panel/top-panel_filter-preferences.png#icon) icon.\n"
 msgstr ""
-"Filter / sortieren\n"
-": Auswahl, wie Bilder gefiltert oder sortiert werden. Kriterien werden im "
+"Filter / Sortierung\n"
+": Auswahl der Filter und Sortierung für Bilder. Kriterien werden im "
 "Modul [Filter- und Sortierung](../../module-reference/utility-modules/shared/"
 "collection-filters.md) geändert oder durch Klicken auf das ![top-"
 "panel_filter-preferences icon](./top-panel/top-panel_filter-preferences."
@@ -24615,8 +24615,8 @@ msgid ""
 "![top-panel_sort-order icon](./top-panel/top-panel_sort-order.png#icon) sort order\n"
 ": Switch the sort order (ascending / descending).\n"
 msgstr ""
-"![top-panel_sort-order icon](./top-panel/top-panel_sort-order.png#icon) sortiere die Reihenfolge\n"
-": Schalte die Reihenfolge (aufsteigend/absteigend).\n"
+"![top-panel_sort-order icon](./top-panel/top-panel_sort-order.png#icon) Sortierung\n"
+": Wechselt zwischen aufsteigender und absteigender Sortierung.\n"
 
 #. type: Title #
 #: content/overview/user-interface/top-panel.md
@@ -24631,8 +24631,8 @@ msgid ""
 "![top panel_grouping icon](./top-panel/top-panel_grouping.png#icon) grouping\n"
 ": Expand or collapse [grouped images](../../lighttable/digital-asset-management/grouping.md).\n"
 msgstr ""
-"![top panel_grouping icon](./top-panel/top-panel_grouping.png#icon) gruppieren\n"
-": Aus- oder Einklappen [gruppierter Bilder](../../lighttable/digital-asset-management/grouping.md).\n"
+"![top panel_grouping icon](./top-panel/top-panel_grouping.png#icon) Gruppierung\n"
+": Blendet [gruppierte Bilder](../../lighttable/digital-asset-management/grouping.md) aus und ein.\n"
 
 #. type: Plain text
 #: content/overview/user-interface/top-panel.md
@@ -24644,7 +24644,7 @@ msgid ""
 msgstr ""
 "![top panel_overlays icon](./top-panel/top-panel_overlays.png#icon) Bildinfo-Einblendungen\n"
 ": Definiert Informationen, die über Vorschaubildern im Leuchttisch/Filmstreifen eingeblendet werden.\n"
-": Definiert werden können Einstellungen abhängig der Größe der Vorschaubilder. Für Details zu _Grenzwerte für größenabhängige Einstellungen_ siehe [darktable-Voreinstellungen > Leuchttisch](../../preferences-settings/lighttable.md#thumbnails).\n"
+": Definiert werden können Einstellungen abhängig von der Größe der Vorschaubilder. Für Details zu _Grenzwerten für größenabhängige Einstellungen_ siehe [darktable-Voreinstellungen > Leuchttisch](../../preferences-settings/lighttable.md#thumbnails).\n"
 
 #. type: Plain text
 #: content/overview/user-interface/top-panel.md
@@ -24654,7 +24654,7 @@ msgid ""
 ": Click this icon and then click on a control element to be directed to the appropriate online help page.\n"
 msgstr ""
 "![top panel_help icon](./top-panel/top-panel_help.png#icon) Kontextabhängige Hilfe\n"
-": Durch Klick auf dieses Symbol und anschließend auf ein Bedienelement wird die zugehörige Seite in der Online-Hilfe im Web-Browser geöffnet.\n"
+": Durch Klick auf dieses Symbol und anschließend auf eines der Bedienelemente, wird die zugehörige Seite in der Online-Hilfe im Web-Browser geöffnet.\n"
 
 #. type: Plain text
 #: content/overview/user-interface/top-panel.md
@@ -24664,7 +24664,7 @@ msgid ""
 ": Click this icon to enter the [visual shortcut mapping](../../preferences-settings/shortcuts.md#visual-shortcut-mapping) mode to create keyboard/mouse shortcuts.\n"
 msgstr ""
 "![top panel shortcut mapping icon](./top-panel/top-panel_shortcut.png#icon) Kurzbefehl definieren\n"
-": Anklicken des Symbol startet die [visuelle Definition eines Kurzbefehls](../../preferences-settings/shortcuts.md#visual-shortcut-mapping), um einen Kurzbefehl mit der Tastatur bzw. der Maus zu erzeugen.\n"
+": Anklicken des Symbol startet die [visuelle Definition eines Kurzbefehls](../../preferences-settings/shortcuts.md#visual-shortcut-mapping), um einen Kurzbefehl mit Tastatur oder Maus festzulegen.\n"
 
 #. type: Plain text
 #: content/overview/user-interface/top-panel.md
@@ -24674,13 +24674,13 @@ msgid ""
 ": View and amend darktable's [preferences & settings](../../preferences-settings/_index.md).\n"
 msgstr ""
 "![top panel_preferences icon](./top-panel/top-panel_preferences.png#icon) darktable-Voreinstellungen\n"
-": siehe und ändere darktables [darktable-Voreinstellungen](../../preferences-settings/_index.md)\n"
+": [darktable-Voreinstellungen](../../preferences-settings/_index.md) anzeigen oder ändern\n"
 
 #. type: Plain text
 #: content/overview/user-interface/filmstrip.md
 #, no-wrap
 msgid "The filmstrip, when enabled, is shown at the bottom of the screen (except in the lighttable view, where it is replaced with the [timeline](../../module-reference/utility-modules/lighttable/timeline.md) module) and displays the images from the current [collection](../../lighttable/digital-asset-management/collections.md) (set in the lighttable view). You can navigate the filmstrip by scrolling with the mouse wheel. \n"
-msgstr "Der Filmstreifen wird, wenn er angewählt ist unten auf dem Bildschirm angezeigt, (außer in der Ansicht Leuchttisch, in der er durch das Modul [Zeitleiste](../../module-reference/utility-modules/lighttable/timeline.md)) ersetzt wird und er zeigt die Bilder der gegenwärtigen [Sammlung](../../lighttable/digital-asset-management/collections.md), (die in der Ansicht Leuchttisch ausgewählt ist.) Du kannst mit dem Mausrad im Filmstreifen navigieren. \n"
+msgstr "Der Filmstreifen wird, falls eingeblendet, unten auf dem Bildschirm angezeigt. In der Ansicht Leuchttisch wird er durch das Modul [Zeitleiste](../../module-reference/utility-modules/lighttable/timeline.md)) ersetzt und zeigt dort die Bilder der gegenwärtigen [Sammlung](../../lighttable/digital-asset-management/collections.md) (die in der Ansicht Leuchttisch ausgewählt ist). Du kannst mit dem Mausrad im Filmstreifen navigieren. \n"
 
 #. type: Plain text
 #: content/overview/user-interface/filmstrip.md
@@ -24689,7 +24689,7 @@ msgid "The filmstrip allows you to interact with images while you are not in the
 msgstr ""
 "Der Filmstreifen erlaubt eine Interaktion mit Bildern außerhalb der Ansicht "
 "Leuchttisch. Zum Beispiel kann während der Entwicklung eines Bildes in der "
-"Dunkelkammer durch Anklicken eines Vorschaubilds im Filmstreifen zum "
+"Dunkelkammer, durch Anklicken eines Vorschaubilds im Filmstreifen, zum "
 "zugehörigen Bild gewechselt werden. Wie im Leuchttisch, können auch "
 "Bewertungen und Farbmarkierungen für Bilder durchgeführt werden, und mit "
 "Kurzbefehlen der Verlaufsstapel übertragen werden.\n"
@@ -24710,25 +24710,25 @@ msgstr "Unterstützte Datei-Formate"
 #: content/overview/supported-file-formats.md
 #, no-wrap
 msgid "darktable supports a huge number of file formats from various camera manufacturers. In addition darktable can read a wide range of low- and high-dynamic-range images -- mainly for data exchange between darktable and other software.\n"
-msgstr "darktable unterstützt eine große Anzahl von Dateiformaten verschiedenster Kamerahersteller. Zusätzlich kann darktable eine Vielzahl von Niedrig- und HDR-Bildern lesen, insbesondere für den Datenaustausch zwischen darktable und anderer Software.\n"
+msgstr "darktable unterstützt eine große Anzahl von Dateiformaten verschiedenster Kamerahersteller. Zusätzlich kann darktable eine Vielzahl Bildern im Niedrig- und Hochdynamikbereich lesen -- hauptsächlich für den Datenaustausch zwischen darktable und anderer Software.\n"
 
 #. type: Plain text
 #: content/overview/supported-file-formats.md
 #, no-wrap
 msgid "In order for darktable to consider a file for import, it must have one of the following extensions (case independent): `3FR, ARI, ARW, BAY, BMQ, CAP, CINE, CR2, CR3, CRW, CS1, DC2, DCR, DNG, GPR, ERF, FFF, EXR, IA, IIQ, JPEG, JPG, JXL, K25, KC2, KDC, MDC, MEF, MOS, MRW, NEF, NRW, ORF, PEF, PFM, PNG, PXN, QTK, RAF, RAW, RDC, RW1, RW2, SR2, SRF, SRW, STI, TIF, TIFF, X3F`\n"
-msgstr "Um eine Datei in darktable importieren zu können, muss diese eine der folgenden Endungen haben (Groß-/Kleinschreibung möglich): `3FR, ARI, ARW, BAY, BMQ, CAP, CINE, CR2, CR3, CRW, CS1, DC2, DCR, DNG, GPR, ERF, FFF, EXR, IA, IIQ, JPEG, JPG, JXL, K25, KC2, KDC, MDC, MEF, MOS, MRW, NEF, NRW, ORF, PEF, PFM, PNG, PXN, QTK, RAF, RAW, RDC, RW1, RW2, SR2, SRF, SRW, STI, TIF, TIFF, X3F`\n"
+msgstr "Um eine Datei in darktable importieren zu können, muss diese eine der folgenden Dateiendungen haben (unabhängig von Groß-/Kleinschreibung): `3FR, ARI, ARW, BAY, BMQ, CAP, CINE, CR2, CR3, CRW, CS1, DC2, DCR, DNG, GPR, ERF, FFF, EXR, IA, IIQ, JPEG, JPG, JXL, K25, KC2, KDC, MDC, MEF, MOS, MRW, NEF, NRW, ORF, PEF, PFM, PNG, PXN, QTK, RAF, RAW, RDC, RW1, RW2, SR2, SRF, SRW, STI, TIF, TIFF, X3F`\n"
 
 #. type: Plain text
 #: content/overview/supported-file-formats.md
 #, no-wrap
 msgid "If darktable was compiled with JPEG2000 support, the following extensions are also recognized: `J2C, J2K, JP2, JPC`.\n"
-msgstr "Falls darktable für eine Unterstützung von JPEG2000 kompiliert wurde, sind folgende Endungen auch akzeptiert: `J2C, J2K, JP2, JPC`.\n"
+msgstr "Falls darktable für eine Unterstützung von JPEG2000 kompiliert wurde, werden folgende Dateiendungen ebenfalls akzeptiert: `J2C, J2K, JP2, JPC`.\n"
 
 #. type: Plain text
 #: content/overview/supported-file-formats.md
 #, no-wrap
 msgid "If darktable was compiled with GraphicsMagick support, the following extensions are also recognized: `BMP, DCM, GIF, JNG, JPC, JP2, MIFF, MNG, PBM, PGM, PNM, PPM, WEBP`.\n"
-msgstr "Falls darktable für die Unterstützung für GraphicsMagick kompiliert wurde, sind auch die folgenden Endungen möglich: `BMP, DCM, GIF, JNG, JPC, JP2, MIFF, MNG, PBM, PGM, PNM, PPM, WEBP`.\n"
+msgstr "Falls darktable für die Unterstützung von GraphicsMagick kompiliert wurde, sind auch die folgenden Dateiendungen möglich: `BMP, DCM, GIF, JNG, JPC, JP2, MIFF, MNG, PBM, PGM, PNM, PPM, WEBP`.\n"
 
 #. type: Title #
 #: content/overview/supported-file-formats.md
@@ -24746,7 +24746,7 @@ msgstr "darktable liest RAW-Dateien mit Hilfe der freien Software-Bibliothek [Ra
 #: content/overview/supported-file-formats.md
 #, no-wrap
 msgid "With the exception of Fujifilm X-Trans cameras, darktable does not decode images from cameras with non-Bayer sensors (e.g. Sigma cameras with the Foveon X3 sensor).\n"
-msgstr "Mit der Ausnahme der Fujifilm X-Trans Kameras, dekodiert darktable keine Bilder mit nicht Bayer Sensoren (wie Sigma Kameras mit dem Foveon X3 Sensor).\n"
+msgstr "Mit Ausnahme der Fujifilm X-Trans Kameras, dekodiert darktable keine Bilder von Kameras ohne Bayer-Sensoren (wie Sigma Kameras mit dem Foveon X3 Sensor).\n"
 
 #. type: Title #
 #: content/overview/supported-file-formats.md
@@ -24758,7 +24758,7 @@ msgstr "Andere Bild-Formate"
 #: content/overview/supported-file-formats.md
 #, no-wrap
 msgid "darktable natively reads “ordinary” images in JPEG, 8-bit/16-bit PNG and 8-bit/16-bit TIFF format, as well as 16-bit/32-bit floating point TIFF formats.\n"
-msgstr "darktable liest von Grund auf auch \"gewöhnliche\" Bilder in JPEG, 8-bit/16-bit PNG und 8-bit/16-bit TIFF Format, wie auch16-bit/32-bit Floating Point TIFF Formate.\n"
+msgstr "darktable liest standardmäßig auch \"gewöhnliche\" Bilder in JPEG, 8-bit/16-bit PNG und 8-bit/16-bit TIFF Format, sowie 16-bit/32-bit Floating Point TIFF Formate.\n"
 
 #. type: Plain text
 #: content/overview/supported-file-formats.md


### PR DESCRIPTION
While reading through the darktable docs in German, I noticed some spelling mistakes and partially weird grammar that I wanted to fix. 

This is only for the "Overview" area. I might create more commits / PRs as soon as I have time to continue reading. 