### PR TITLE
Document descriptions for color labels

### DIFF
--- a/content/lighttable/lighttable-view-layout.md
+++ b/content/lighttable/lighttable-view-layout.md
@@ -63,7 +63,7 @@ From left to right:
 : Apply star ratings to images.
 
 [color labels](./digital-asset-management/star-color.md)
-: Apply color labels to images. Right-click to assign a descriptive name to any color label.
+: Apply color labels to images. Right-click to assign a descriptive name to any color label. The description is displayed only in the tooltip that appears when hovering over the color label (and not in collection filters or any other UI element).
 
 [mode selector](./lighttable-modes/_index.md)
 : Choose a lighttable mode.

--- a/content/lighttable/lighttable-view-layout.md
+++ b/content/lighttable/lighttable-view-layout.md
@@ -63,7 +63,7 @@ From left to right:
 : Apply star ratings to images.
 
 [color labels](./digital-asset-management/star-color.md)
-: Apply color labels to images.
+: Apply color labels to images. Right-click to assign a descriptive name to any color label.
 
 [mode selector](./lighttable-modes/_index.md)
 : Choose a lighttable mode.


### PR DESCRIPTION
# Please include a link to the Pull Request that you are documenting
For https://github.com/darktable-org/darktable/pull/16139.

# Tell us a little bit about this pull request
Added a short description mentioning the right-click to assign a description.

Note: is the label shown anywhere? I know it's shown in the tooltip (here: _experiment_):
![image](https://github.com/user-attachments/assets/8b18908b-2d60-49f6-8e22-ee6d9474ed69)

But e.g. in filters, only the colour is shown:
![image](https://github.com/user-attachments/assets/2a7af948-7770-4107-94e6-70cd88e45379)
Same for the filter:
![image](https://github.com/user-attachments/assets/ae1b18e3-45af-4365-82e9-0202682d45b0)
