### PR TITLE
Update README.md: corrected hugo version

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,9 @@ If you already have the site cloned, but haven't included the submodules before:
 
 ### Hugo
 
-This site is built with the static site generator Hugo (*extended*).
-Currently v0.75.1 extended:
-```
-$ ./hugo version
-Hugo Static Site Generator v0.73.0/extended windows/amd64 BuildDate: unknown
-```
+This site is built with the static site generator [Hugo](https://github.com/gohugoio/hugo) (*extended*).
+
+You can use a prebuilt binary of the latest *extended* version for your system. A detailed guide for installation of the prebuilt binaries is given in the [Hugo installation documentation](https://gohugo.io/installation/).
 
 #### SASS
 


### PR DESCRIPTION
The required hugo version was outdated in the readme. A reference on how to install the latest hugo version was added instead.

# Please include a link to the Pull Request that you are documenting
None, since it is relevant to the dtdocs readme.
# Tell us a little bit about this pull request
This pull request is intended to clarify the readme of the dtdocs repository, see Issue #709 