### PR TITLE
Documented how to override the default exposure and black point adjustment behavior in the histogram...

### DIFF
--- a/content/module-reference/utility-modules/shared/scopes.md
+++ b/content/module-reference/utility-modules/shared/scopes.md
@@ -119,7 +119,13 @@ For horizontal waveform and RGB parade, drag the upper portion of the scope up/d
 
 For vertical waveform and RGB parade scopes, the corresponding regions are to the right (exposure) and left (black level).
 
-You can also scroll in the appropriate area -- rather than dragging -- to adjust exposure and black point. Double-click in the scope to reset the exposure module's parameters to their defaults.
+You can also scroll in the appropriate area -- rather than dragging -- to adjust exposure and black point.
+
+There are the following overrides for the default behavior:
+
+- hold Ctrl+Shift while adjusting to override the soft limits (e.g. to significantly overexpose the image)
+- hold Ctrl while adjusting or right-click to fine-tune the adjustment
+- double-click on the desired area to reset to the original value
 
 # histogram profile
 

--- a/content/module-reference/utility-modules/shared/scopes.md
+++ b/content/module-reference/utility-modules/shared/scopes.md
@@ -124,7 +124,7 @@ You can also scroll in the appropriate area -- rather than dragging -- to adjust
 There are the following overrides for the default behavior:
 
 - hold Ctrl+Shift while adjusting to override the soft limits (e.g. to significantly overexpose the image)
-- hold Ctrl while adjusting or right-click to fine-tune the adjustment
+- hold Ctrl while adjusting to fine-tune the adjustment. Alternatively, right-click to enter a precise value for the adjustment
 - double-click on the desired area to reset to the original value
 
 # histogram profile


### PR DESCRIPTION
# Please include a link to the Pull Request that you are documenting

[PR17838](https://github.com/darktable-org/darktable/pull/17838)

# Tell us a little bit about this pull request

This documents how to modify the behavior when adjusting exposure/black point in the histogram, waveform, or rgb parade scopes.