### PR TITLE
added undo/redo shortcuts to filmstrip and documented new selection behavior

### DIFF
--- a/content/module-reference/utility-modules/shared/filmstrip.md
+++ b/content/module-reference/utility-modules/shared/filmstrip.md
@@ -44,8 +44,4 @@ The following shortcuts can be used to perform operations on the selected images
 
 - `Ctrl+Shift+V` selectively pastes from the copied history stack
 
-- `Ctrl+Z` performs an undo on the last history stack operation
-
-- `Ctrl+Y` performs a redo on the last history stack operation
-
 See the lighttable's [history stack](../lighttable/history-stack.md) module documentation for more information about the copy and paste functionality.

--- a/content/module-reference/utility-modules/shared/filmstrip.md
+++ b/content/module-reference/utility-modules/shared/filmstrip.md
@@ -16,7 +16,7 @@ Quickly navigate through the images in the filmstrip by scrolling with the mouse
 
 In the darkroom, the image currently being processed is selected and highlighted. Hover over an image on the filmstrip with your mouse to select it (in order to act on it with a keyboard shortcut) without changing the image being processed.
 
-If you wish to select multiple images in the filmstrip, use Alt+click to select the first image, followed by either Ctrl+click to select or de-select further images, or Shift+click to select a range of images.
+If you wish to select multiple images in the filmstrip, click to select the first image followed by either Ctrl+click to select or de-select further images, or Shift+click to select a range of images.
 
 The following shortcuts can be used to select images in the filmstrip:
 
@@ -43,5 +43,9 @@ The following shortcuts can be used to perform operations on the selected images
 - `Ctrl+Shift+C` selectively copies the history stack
 
 - `Ctrl+Shift+V` selectively pastes from the copied history stack
+
+- `Ctrl+Z` performs an undo on the last history stack operation
+
+- `Ctrl+Y` performs a redo on the last history stack operation
 
 See the lighttable's [history stack](../lighttable/history-stack.md) module documentation for more information about the copy and paste functionality.


### PR DESCRIPTION
# Please include a link to the Pull Request that you are documenting

[PR17563](https://github.com/darktable-org/darktable/pull/17563) and [PR17568](https://github.com/darktable-org/darktable/pull/17568)

# Tell us a little bit about this pull request

Added undo/redo shortcuts to filmstrip and documented new behavior for selecting a range of images
