### PR TITLE
Update location of 'enable disk backend for full preview cache' preference in lighttable docs

### DIFF
--- a/content/lighttable/lighttable-modes/culling.md
+++ b/content/lighttable/lighttable-modes/culling.md
@@ -36,6 +36,6 @@ dynamic mode
 
 ---
 
-**Hint:** To enhance performance when loading zoomed images, you can enable ([preferences > processing > cpu/gpu/memory > enable disk backend for full preview cache](../../preferences-settings/processing.md#cpu--gpu--memory)). Bear in mind that this can occupy a lot of disk space.
+**Hint:** To enhance performance when loading zoomed images, you can enable ([preferences > lighttable > thumbnails > enable disk backend for full preview cache](../../preferences-settings/lighttable.md#thumbnails)). Bear in mind that this can occupy a lot of disk space.
 
 ---


### PR DESCRIPTION
# Please include a link to the Pull Request that you are documenting
https://github.com/darktable-org/darktable/pull/15294

# Tell us a little bit about this pull request
The preference has moved, its documentation has been updated, but the link from the lighttable page has been forgotten.