### PR TITLE
Document the find tag menu item in attached tags area

### DIFF
--- a/content/module-reference/utility-modules/shared/tagging.md
+++ b/content/module-reference/utility-modules/shared/tagging.md
@@ -213,6 +213,10 @@ The “export” button exports your entire tag dictionary into a text file of y
 
 It is possible to copy a single selected tag to the clipboard from both _attached tags_ and _tag dictionary_ sections by using the pop-up menu entry "copy to clipboard".
 
+## find tag
+
+If you right click on a tag name in the _attached tags_ section and click _find tag_ then the _tag dictionary_ will show all matching tags.
+
 ## keyboard
 
 The following keys can be used within the tagging module:

--- a/content/module-reference/utility-modules/shared/tagging.md
+++ b/content/module-reference/utility-modules/shared/tagging.md
@@ -215,7 +215,7 @@ It is possible to copy a single selected tag to the clipboard from both _attache
 
 ## find tag
 
-If you right click on a tag name in the _attached tags_ section and click _find tag_ then the _tag dictionary_ will show all matching tags.
+If you right click on a tag name in the _attached tags_ section and click _find tag_, then the _tag dictionary_ will show all matching tags.
 
 ## keyboard
 


### PR DESCRIPTION
Related to this PR: https://github.com/darktable-org/darktable/pull/16208

Add a doc note that there is a _find tag_ menu item in the tagging module for finding tags in the tag dictionary matching an attached tag.