### PR TITLE
Update refinement-controls.md to add refinement of raster masks per DT PR #18606

### DIFF
--- a/content/darkroom/masking-and-blending/masks/refinement-controls.md
+++ b/content/darkroom/masking-and-blending/masks/refinement-controls.md
@@ -5,7 +5,7 @@ weight: 50
 draft: false
 ---
 
-When a parametric or drawn mask is active, several additional sliders are shown which allow the mask to be further refined.
+When a parametric or drawn mask is active, several additional sliders are shown which allow the mask to be further refined. Raster masks may also be refined using these same controls.
 
 details threshold
 : This control allows you to alter the opacity of the mask based on the amount of detail in the image. Use this slider to select either areas with lots of detail (positive values) or areas that are flat and lacking in detail (negative values). The default (zero) effectively bypasses details refinement. This is mostly useful to apply sharpening and blurring effects that ignore out-of-focus (bokeh) regions or to sharpen only blurry parts, preventing over-sharpening of in-focus regions.

--- a/content/darkroom/masking-and-blending/masks/refinement-controls.md
+++ b/content/darkroom/masking-and-blending/masks/refinement-controls.md
@@ -5,7 +5,7 @@ weight: 50
 draft: false
 ---
 
-When a parametric or drawn mask is active, several additional sliders are shown which allow the mask to be further refined. Raster masks may also be refined using these same controls.
+When a mask is active, several additional sliders are shown which allow the mask to be further refined.
 
 details threshold
 : This control allows you to alter the opacity of the mask based on the amount of detail in the image. Use this slider to select either areas with lots of detail (positive values) or areas that are flat and lacking in detail (negative values). The default (zero) effectively bypasses details refinement. This is mostly useful to apply sharpening and blurring effects that ignore out-of-focus (bokeh) regions or to sharpen only blurry parts, preventing over-sharpening of in-focus regions.


### PR DESCRIPTION
Thank you for taking the time to help the darktable documentation!

This refers to DT [DT #18606](https://github.com/darktable-org/darktable/pull/18606), Raster masks get refinement processing.  The change simply notes that raster masks get refinements as other masks.
