### PR TITLE
Update import.md with improved clarity

### DIFF
--- a/content/preferences-settings/import.md
+++ b/content/preferences-settings/import.md
@@ -28,14 +28,14 @@ $(MAX_WIDTH)         maximum image width to limit within export session
 $(MAX_HEIGHT)        maximum image height to limit within export session
 $(ID)                unique identification number of the image in darktable's database
 $(YEAR)              year at the date of import
-$(MONTH)             month at the date of import
-$(DAY)               day at the date of import
+$(MONTH)             numerical month at the date of import
+$(DAY)               numerical day at the date of import
 $(HOUR)              hour at the time of import
 $(MINUTE)            minute at the time of import
 $(SECOND)            second at the time of import
 $(EXIF_YEAR)         year the photo was taken (from Exif data)
-$(EXIF_MONTH)        month the photo was taken (from Exif data)
-$(EXIF_DAY)          day the photo was taken (from Exif data)
+$(EXIF_MONTH)        numerical month the photo was taken (from Exif data)
+$(EXIF_DAY)          numerical day the photo was taken (from Exif data)
 $(EXIF_HOUR)         hour the photo was taken (from Exif data)
 $(EXIF_MINUTE)       minute the photo was taken (from Exif data)
 $(EXIF_SECOND)       seconds the photo was taken (from Exif data)


### PR DESCRIPTION


# Please include a link to the Pull Request that you are documenting
https://github.com/rforzachamp821/dtdocs_monthimprovement

# Tell us a little bit about this pull request
Explicitly specified the formatting (numerical) for all month and day session options. This improves clarity, as it defines specifically how the month and day is formatted as the options are read, since users could think that darktable uses alphabetical naming (e.g expecting darktable to format the month as "January" instead of "01").