### PR TITLE
Replace use of camera manufacturer with maker

### DIFF
--- a/content/module-reference/processing-modules/base-curve.md
+++ b/content/module-reference/processing-modules/base-curve.md
@@ -11,9 +11,9 @@ masking: true
 
 Simulate the in-camera JPEG by applying a characteristic base curve to the image.
 
-darktable comes with a number of base curve presets that attempt to mimic the curves of various camera manufacturers. These presets are automatically applied according to the manufacturer ID found in the image's Exif data. Camera-specific base curve presets are also available for some camera models. 
+darktable comes with a number of base curve presets that attempt to mimic the curves of various camera makers. These presets are automatically applied according to the maker ID found in the image's Exif data. Camera-specific base curve presets are also available for some camera models. 
 
-This module will be enabled by default if [preferences > processing > auto-apply pixel workflow defaults](../../preferences-settings/processing.md) is set to "display-referred".  A second option in the preferences dialog allows you to choose whether darktable should attempt to apply a camera-specific base curve (if found) or the generic manufacturer one.
+This module will be enabled by default if [preferences > processing > auto-apply pixel workflow defaults](../../preferences-settings/processing.md) is set to "display-referred".  A second option in the preferences dialog allows you to choose whether darktable should attempt to apply a camera-specific base curve (if found) or the generic maker one.
 
 # module controls
 

--- a/content/module-reference/processing-modules/color-calibration.md
+++ b/content/module-reference/processing-modules/color-calibration.md
@@ -307,7 +307,7 @@ This feature can assist with:
 
 ## supported color checker targets
 
-Users are not currently permitted to use custom targets, but a limited number of verified color checkers (from reputable manufacturers) are supported:
+Users are not currently permitted to use custom targets, but a limited number of verified color checkers (from reputable makers) are supported:
 
 -   X-Rite / Gretag MacBeth Color Checker 24 (pre- and post-2014),
 -   Datacolor SpyderCheckr 24 (pre- and post-2018),

--- a/content/module-reference/processing-modules/denoise-profiled.md
+++ b/content/module-reference/processing-modules/denoise-profiled.md
@@ -13,7 +13,7 @@ An easy to use and highly efficient denoise module, adapted to the individual no
 
 One issue with a lot of denoising algorithms is that they assume that the variance of the noise is independent of the luminosity of the signal. By profiling the noise characteristics of a camera's sensor at different ISO settings, the variance at different luminosities can be assessed, and the denoising algorithm can be adjusted to more evenly smooth out the noise.
 
-Currently, darktable has sensor noise profiles for over 300 popular camera models from all the major manufacturers. If you generate your own noise profile for a camera that is not yet supported by darktable, be sure to share it with the darktable development team so they can include it in the next release! Please see darktable's [camera support](https://github.com/darktable-org/darktable/wiki/Camera-support) page for more information.
+Currently, darktable has sensor noise profiles for over 300 popular camera models from all the major makers. If you generate your own noise profile for a camera that is not yet supported by darktable, be sure to share it with the darktable development team so they can include it in the next release! Please see darktable's [camera support](https://github.com/darktable-org/darktable/wiki/Camera-support) page for more information.
 
 # modes
 

--- a/content/module-reference/processing-modules/input-color-profile.md
+++ b/content/module-reference/processing-modules/input-color-profile.md
@@ -22,7 +22,7 @@ Note that the final color profile that will be used when exporting the image is 
 # module controls
 
 input profile
-: The profile or color matrix to apply. A number of matrices are provided along with an enhanced color matrix for some camera models. The enhanced matrices are designed to provide a look that is closer to that of the camera manufacturer.
+: The profile or color matrix to apply. A number of matrices are provided along with an enhanced color matrix for some camera models. The enhanced matrices are designed to provide a look that is closer to that of the camera maker.
 
 : You can also supply your own input ICC profiles and put them into `$DARKTABLE/share/darktable/color/in` or `$HOME/.config/darktable/color/in` (where `$DARKTABLE` is the darktable installation directory and `$HOME` is your home directory). Note that these `color/in` directories are not created by the darktable install; if you need to use one, you must create it yourself. One common source of ICC profiles is the software that is shipped with your camera, which often contains profiles specific to your camera model. You may need to activate the [_unbreak input profile_](./unbreak-input-profile.md) module to use your own profiles.
 

--- a/content/module-reference/processing-modules/unbreak-input-profile.md
+++ b/content/module-reference/processing-modules/unbreak-input-profile.md
@@ -11,7 +11,7 @@ masking: true
 
 Add a correction curve to image data. This is required if you have selected certain input profiles in the [_input color profile_](./input-color-profile.md) module.
 
-If you decide to use an ICC profile from the camera manufacturer in the [_input color profile_](./input-color-profile.md) module, a correction curve frequently needs to be pre-applied to image data to prevent the final output from looking too dark. This extra processing is not required if you use darktable's standard or enhanced color matrices. 
+If you decide to use an ICC profile from the camera maker in the [_input color profile_](./input-color-profile.md) module, a correction curve frequently needs to be pre-applied to image data to prevent the final output from looking too dark. This extra processing is not required if you use darktable's standard or enhanced color matrices. 
 
 The correction curve is defined with a linear part extending from the shadows to some upper limit and a gamma curve covering mid-tones and highlights. For further information please see darktable's neighboring project [UFRaw](http://ufraw.sourceforge.net).
 
@@ -19,4 +19,4 @@ linear
 : The upper limit for the region counted as shadows and where no gamma correction is performed. Typically values between 0.0 and 0.1 are required by the profile.
 
 gamma
-: The gamma value required to compensate the input profile. Often the required value is 0.45 (the reciprocal of the 2.2 gamma used by some manufacturer's profiles).
+: The gamma value required to compensate the input profile. Often the required value is 0.45 (the reciprocal of the 2.2 gamma used by some maker's profiles).

--- a/content/overview/supported-file-formats.md
+++ b/content/overview/supported-file-formats.md
@@ -6,7 +6,7 @@ weight: 20
 author: "people"
 ---
 
-darktable supports a huge number of file formats from various camera manufacturers. In addition darktable can read a wide range of low- and high-dynamic-range images -- mainly for data exchange between darktable and other software.
+darktable supports a huge number of file formats from various camera makers. In addition darktable can read a wide range of low- and high-dynamic-range images -- mainly for data exchange between darktable and other software.
 
 In order for darktable to consider a file for import, it must have one of the following extensions (case independent): `3FR, ARI, ARW, BAY, BMQ, CAP, CINE, CR2, CR3, CRW, CS1, DC2, DCR, DNG, GPR, ERF, FFF, EXR, IA, IIQ, JPEG, JPG, JXL, K25, KC2, KDC, MDC, MEF, MOS, MRW, NEF, NRW, ORF, PEF, PFM, PNG, PXN, QTK, RAF, RAW, RDC, RW1, RW2, SR2, SRF, SRW, STI, TIF, TIFF, X3F`
 

--- a/content/preferences-settings/processing.md
+++ b/content/preferences-settings/processing.md
@@ -46,7 +46,7 @@ auto-apply pixel workflow defaults
 -   _none_ sets the module order to _v3.0 RAW_ and uses the _white balance_ module for chromatic adaptation. No other exposure or tone mapping modules are enabled by default.
 
 auto-apply per camera basecurve presets
-: Use a per-camera base curve by default (if available) instead of the generic manufacturer one. This should only be used in conjunction with the _display-referred_ workflow defined above (default off).
+: Use a per-camera base curve by default (if available) instead of the generic maker one. This should only be used in conjunction with the _display-referred_ workflow defined above (default off).
 
 detect monochrome previews
 : Enable this option to analyse images during import and tag them with the `darkroom|mode|monochrome` tag if they are found to be monochrome. The analysis is based on the preview image embedded within the imported file. This makes for a more convenient workflow when working with monochrome images, but it slows down the import, so this setting is disabled by default.


### PR DESCRIPTION
Related darktabke issue: https://github.com/darktable-org/darktable/pull/18897

Replace uses of _camera manufacturer_ with _camera maker_. I'm not sure if the sentences now sometimes read a little oddly, but this makes it more consistent with darktable itself.

I have not changed other uses of manufacturer (e.g. printer or GPU manufacturer). 
