### PR TITLE
Update lighttable preferences for prioritize hover for action

### DIFF
--- a/content/preferences-settings/lighttable.md
+++ b/content/preferences-settings/lighttable.md
@@ -15,6 +15,9 @@ hide built-in presets for utility modules
 use single-click in the collections module
 : Enable "single click" mode in the [collections](../module-reference/utility-modules/shared/collections.md) module, which allows ranges to be selected (default off).
 
+prioritize the hovered image over the selected images
+: Controls which images are affected by an action (e.g. using the keyboard to set the number of stars). If this option is enabled, only the image hovered over is affected. If disabled, all the selected images are affected and the hovered over image is only affected if it is also one of the selected images. (default on)
+
 expand a single utility module at a time
 : Controls how utility modules are expanded. If this option is enabled, expanding a module by clicking collapses any other currently expanded panel. If you want to expand a panel without collapsing the others you can do so with Shift+click. Disabling this option inverts the meaning of click and Shift+click (default off).
 


### PR DESCRIPTION
Related darktable issue: https://github.com/darktable-org/darktable/pull/18484

Add the lighttable preference about whether to prioritize hovered over image or the selected images for actions.