### PR TITLE
Clarity and structure improvements in the shortcuts documentations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ public/*
 public-epub/*
 public-pdf/*
 .hugo_build.lock
-.vscode/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ public/*
 public-epub/*
 public-pdf/*
 .hugo_build.lock
+.vscode/settings.json

--- a/content/preferences-settings/shortcuts.md
+++ b/content/preferences-settings/shortcuts.md
@@ -148,7 +148,7 @@ For example, you can assign the shortcut `e + scroll` to change the value (the _
 
 # assigning shortcuts to actions
 
-There are two primary methods of assigning shortcuts to actions: [visual shortcut mapping](#visual-shortcut-mapping) (recommended) and the [shortcut mapping screen](#shortcut-mapping-screen). The former makes it easier to remap multiple shortcuts at once, while the latter allows for finer control and more flexibility. Both options are detailed below.
+There are two primary methods of assigning shortcuts to actions: [visual shortcut mapping](#visual-shortcut-mapping) (recommended) and the [shortcut mapping screen](#shortcut-mapping-screen). The former makes it easier to remap multiple shortcuts at once, while the latter allows for finer control and more flexibility.
 
 ## visual shortcut mapping
 

--- a/content/preferences-settings/shortcuts.md
+++ b/content/preferences-settings/shortcuts.md
@@ -39,7 +39,7 @@ Similarly, to control a slider with a shortcut you can:
 The system is very flexible and powerful, and this is just scratching the surface.
 Keep on reading to understand it better and learn how to make the most of it.
 
-# types of actions and shortcuts
+# types of shortcuts and actions
 
 There are two types of actions:
 

--- a/content/preferences-settings/shortcuts.md
+++ b/content/preferences-settings/shortcuts.md
@@ -47,9 +47,13 @@ If you have an external controller, you can trigger discrete actions by pressing
 # anatomy of a shortcut
 
 The simplest shortcut consists of just one key press (e.g., `E`).
+
 The same key can be repeated up to three times, so also `E + E` and `E + E + E` are valid, and distinct, shortcuts.
+
 You can further extend a shortcut with up to three clicks of different mouse buttons. So, `E + E + left-click` or `E + right-click + left-click` are also valid shortcuts.
+
 Finally, if your fingers are very nimble and you really need to go there, you can repeat the last click up to three times. So, also `E + left-click + middle-click + middle-click` and `E + E + middle-click + left-click + right-click + right-click + right-click` are valid shortcuts.
+
 Hence, the most complex shortcut can consist of 8 key/button presses:
 * Three key presses of the same `key`, followed by
 * Three presses of the three mouse buttons, followed by
@@ -66,13 +70,13 @@ If you are a MacOs user, your shortcuts will use `Cmd` instead of `Ctrl` and `Op
 
 If you are defining a continuous shortcut, then the movement part of the shortcut must be executed while the last key, mouse or controller button is held down.
 
-For example, the shortcut `E + E + pan`, can be activated by pressing `E` twice, holding down `E` on the second press and moving the mouse horizontally. While you are holding down `E`, moving the mouse horizontally will adjust the value associated with the shortcut's action. As you release the `E` key, moving the mouse horizontally will just move the mouse on the screen.
+For example, the shortcut `E + E + pan`, can be activated by pressing `E` twice, holding down `E` on the second press and moving the mouse horizontally and moving the mouse horizontally will the key is pressed.
 
-**Long keypresses.** 
-The last repetition of a key in a shortcut can be either a _short_ (i.e., normal) or _long_ keypress, defined as holding down the key for a bit longer than the duration of a double click. Hence `E + E` and `E + E(long)` are two distinct shortcuts that can be assigned to different actions. The associated action triggers when the key is released, which entails that a shortcut ending with a long press cannot be used for a continuos shortcut.
+**Short and long keypresses.** 
+By default, all keypresses in a shortcut are _short_, i.e., the key is pressed and immediately released. However, the last repetition of a key in a shortcut can also be a _long_ keypress, defined as holding down the key for a bit longer than the duration of a double click. Hence `E + E` and `E + E(long)` are two distinct shortcuts that can be assigned to different actions. The associated action triggers when the key is released, which entails that a shortcut ending with a long press cannot be used for a continuos shortcut.
 
 **Triggering multiple shortcuts at once.** Note that `E + A` is not a valid shortcut, and darktable will interpret it as a two different shortcuts: `E` followed by `A`. This is by design, as the system allows one to trigger multiple continuous shortcuts at once.
-For example, if both `E + scroll` and `A + scroll` are mapped to a slider (or if you have fallbacks enabled), then scrolling with the mouse while holding down both `E` and `A` will move both sliders. If you have a series of keys assigned to nodes in a curve (e.g, tone equalizer) this allows you to move multiple nodes in parallel.
+For example, if both `E + mouse-scroll` and `A + mouse-scroll` are mapped to a slider (or if you have fallbacks enabled), then scrolling with the mouse while holding down both `E` and `A` will move both sliders. If you have a series of keys assigned to nodes in a curve (e.g, tone equalizer) this allows you to move multiple nodes in parallel.
 
 **Shortcuts must be unique within a view.**
 A single action may have multiple shortcuts but a single shortcut can only be linked to one action in a given darktable view -- you can't chain actions together except by applying a preset or style. You can, however, set up a single shortcut that does one thing in the lighttable view, say, and another in the darkroom view.

--- a/content/preferences-settings/shortcuts.md
+++ b/content/preferences-settings/shortcuts.md
@@ -64,7 +64,7 @@ Finally, if your fingers are very nimble and you really need to go there, you ca
 Hence, the most complex shortcut can consist of 8 key/button presses:
 * Three key presses of the same `key`, followed by
 * Three presses of the three mouse buttons, followed by
-* 2 more repetions of the last click.
+* 2 more repetitions of the last click.
 
 Your shortcut can include one or more modifiers (`Shift`, `Ctrl` and `Alt`). In this case, the modifier(s) have to be held down while executing the remainder of the shortcut. So, `Ctrl + E + E` means holding down `Ctrl` while pressing `E` twice in a rapid sequence.
 
@@ -79,11 +79,12 @@ If you are defining a continuous shortcut, then the movement part of the shortcu
 
 For example, the shortcut `E + E + pan`, can be activated by pressing `E` twice, holding down `E` on the second press and moving the mouse horizontally and moving the mouse horizontally will the key is pressed.
 
-**Short and long keypresses.** 
-By default, all keypresses in a shortcut are _short_, i.e., the key is pressed and immediately released. However, the last repetition of a key in a shortcut can also be a _long_ keypress, defined as holding down the key for a bit longer than the duration of a double click. Hence `E + E` and `E + E(long)` are two distinct shortcuts that can be assigned to different actions. The associated action triggers when the key is released, which entails that a shortcut ending with a long press cannot be used for a continuos shortcut.
+**Short and long key presses.** 
+By default, all key presses in a shortcut are _short_, i.e., the key is pressed and immediately released. However, the last repetition of a key in a shortcut can also be a _long_ keypress, defined as holding down the key for a bit longer than the duration of a double click. Hence `E + E` and `E + E(long)` are two distinct shortcuts that can be assigned to different actions. The associated action triggers when the key is released, which entails that a shortcut ending with a long press cannot be used for a continuos shortcut.
 
-**Triggering multiple shortcuts at once.** Note that `E + A` is not a valid shortcut, and darktable will interpret it as a two different shortcuts: `E` followed by `A`. This is by design, as the system allows one to trigger multiple continuous shortcuts at once.
-For example, if both `E + mouse-scroll` and `A + mouse-scroll` are mapped to a slider (or if you have fallbacks enabled), then scrolling with the mouse while holding down both `E` and `A` will move both sliders. If you have a series of keys assigned to nodes in a curve (e.g, tone equalizer) this allows you to move multiple nodes in parallel.
+**Triggering multiple shortcuts at once.** 
+If both `E + mouse-scroll` and `F + mouse-scroll` are mapped to a slider (or if you have fallbacks enabled), then scrolling the mouse wheel while holding down both `E` and `F` will move both sliders.
+Similarly, you could map, say, `E + E + mouse-scroll` and `F + F + mouse-scroll` to two nodes in a graph (say, `yellow` and `green` in color equalizer). You can then use `E + E(hold) + F(hold) + mouse-scroll` to move both sliders at once. This works because the repeat key counter is per-shortcut, not per key, and it is reset only after the current shortcut ends (i.e., when the repeated key is released). Thus it is possible to trigger as many actions at once as your fingers can handle, provided that all the shortcuts involved have the same number of key presses (i.e., single, double or triple presses).
 
 **Shortcuts must be unique within a view.**
 A single action may have multiple shortcuts but a single shortcut can only be linked to one action in a given darktable view -- you can't chain actions together except by applying a preset or style. You can, however, set up a single shortcut that does one thing in the lighttable view, say, and another in the darkroom view.
@@ -235,7 +236,7 @@ _enable_
 : Acts as a _toggle_ that switches the module on and off.
 
 _focus_
-: Acts as a _toggle_ that focuses or defocuses the module. This is useful for modules such as [_crop_](../module-reference/processing-modules/crop.md) or [_tone equalizer_](../module-reference/processing-modules/tone-equalizer.md), whose on-screen controls are only activated when those modules have focus. For _crop_, changes are saved only when the module loses focus.
+: Acts as a _toggle_ that focuses or de-focuses the module. This is useful for modules such as [_crop_](../module-reference/processing-modules/crop.md) or [_tone equalizer_](../module-reference/processing-modules/tone-equalizer.md), whose on-screen controls are only activated when those modules have focus. For _crop_, changes are saved only when the module loses focus.
 
 _instance_
 : Allows you to select actions from the [multiple-instance](../darkroom/processing-modules/multiple-instances.md) menu (e.g. move up/down, create new instance). The discrete action associated to the _instance_ element displays a list of the available options for selection; a continuous action is also available and will move the _preferred module instance_ (see below) up and down the pixelpipe.

--- a/content/preferences-settings/shortcuts.md
+++ b/content/preferences-settings/shortcuts.md
@@ -5,7 +5,7 @@ weight: 120
 draft: false
 ---
 
-_Shortcuts_ are a way to control darktable using your keyboard, mouse or trackpad and other input devices. They allow you to perform _actions_ without interacting directly with a UI element.
+_Shortcuts_ are a way to control darktable using your keyboard, mouse, trackpad, or other input devices. They allow you to perform _actions_ without interacting directly with a UI element.
 
 An _action_ is usually an operation that you might undertake using darktable's point-and-click user interface.
 See [common actions](#common-actions) for a list of the most common ones. For example:

--- a/content/preferences-settings/shortcuts.md
+++ b/content/preferences-settings/shortcuts.md
@@ -60,7 +60,7 @@ Your shortcut can include one or more modifiers (`Shift`, `Ctrl` and `Alt`). In 
 ---
 
 **Note:**
-If you are a MacOs user, your shortcuts will use `Cmd` instead of `Ctrl` and `Option` instead of `Alt`
+If you are a MacOs user, your shortcuts will use `Cmd` instead of `Ctrl` and `Option` instead of `Alt`.
 
 ---
 

--- a/content/preferences-settings/shortcuts.md
+++ b/content/preferences-settings/shortcuts.md
@@ -181,7 +181,7 @@ left-click on a mappable widget to open the shortcut mapping screen for that wid
 define a second shortcut against the same widget. If you attempt to reallocate an existing shortcut to a new action, you will be notified of the conflict and prompted to replace the existing shortcut.
 
 **To change the default speed of a slider:**
-scroll with your mouse wheel while in visual mapping mode (without pressing any other buttons/keys) when hovering over the slider -- scroll up to increase and down to decrease. When you leave mapping mode, normal mouse scrolls over that slider will change its value with the adjusted speed.
+Scroll with your mouse wheel while in visual mapping mode (without pressing any other buttons/keys) when hovering over the slider -- scroll up to increase and down to decrease. When you leave mapping mode, normal mouse scrolls over that slider will change its value with the adjusted speed.
 
 ## shortcut mapping screen
 

--- a/content/preferences-settings/shortcuts.md
+++ b/content/preferences-settings/shortcuts.md
@@ -62,7 +62,7 @@ For example:
 ---
 
 **Note:**
-By construction, a _directional shortcut_ is sufficiently expressive to trigger a _discrete action_. The opposite is not true. However, it is possible to use a combination of two _discrete shortcuts_ to control a _directional action_. For example, you can use two different shortcuts to trigger the `up` and `down` effects of a slider (see [anatomy of an action](#anatomy-of-an-action)).
+A _directional shortcut_ is sufficient to trigger a _discrete action_. The opposite is not true. However, it is possible to use a combination of two _discrete shortcuts_ to control a _directional action_. For example, you can use two different shortcuts to trigger the `up` and `down` effects of a slider (see [anatomy of an action](#anatomy-of-an-action)).
 
 ---
 

--- a/content/preferences-settings/shortcuts.md
+++ b/content/preferences-settings/shortcuts.md
@@ -171,7 +171,7 @@ Press a key combination while hovering over a mappable widget. A _default action
 You can assign as many shortcuts as you like in a single mapping session and then exit mapping mode when you are finished by clicking the ![visual mapping button](./shortcuts/visual-mapping-button.png#icon) icon again or right-clicking anywhere on the screen.
 
 **To explore already defined shortcuts:**
-left-click on a mappable widget to open the shortcut mapping screen for that widget (see below). Left-click anywhere else on the screen to open the shortcut mapping screen, expanded (where possible) based on the part of the screen you have clicked on. This screen can be used to alter the action assigned to a shortcut and to configure shortcuts for non-visual actions. Entering the shortcut mapping screen exits visual shortcut mapping mode.
+Left-click on a mappable widget to open the shortcut mapping screen for that widget (see below). Left-click anywhere else on the screen to open the shortcut mapping screen, expanded (where possible) based on the part of the screen you have clicked on. This screen can be used to alter the action assigned to a shortcut and to configure shortcuts for non-visual actions. Entering the shortcut mapping screen exits visual shortcut mapping mode.
 
 **To update existing shortcuts:**
 define a second shortcut against the same widget. If you attempt to reallocate an existing shortcut to a new action, you will be notified of the conflict and prompted to replace the existing shortcut.

--- a/content/preferences-settings/shortcuts.md
+++ b/content/preferences-settings/shortcuts.md
@@ -306,3 +306,9 @@ To see a list of _all_ of the default fallbacks, click the "enable fallbacks" ch
 Fallbacks are only applied if no other shortcut using the resulting combination has been explicitly created. In the above example, if you were to explicitly assign `Ctrl + R + left-click` to another action, the "enable/disable module" fallback would be ignored.
 
 Some fallback actions are defined using modifier keys (usually `Ctrl+` and `Shift+`). In this case you must define an initial shortcut without such a modifier in order to be able to use these fallbacks. For example, if you assign `Ctrl + R` to an action, you cannot use a `Ctrl+` fallback. Some default fallbacks of this type are provided for the _value_ element and for horizontal/vertical movements in the (zoomed) central area -- in this case, `Shift+` increases the speed to 10.0 and `Ctrl+` decreases the speed to 0.1.
+
+# implementation details
+
+This section covers some technical aspects that can be interesting for power users.
+
+**Continuous actions:** Continuous actions are convenience abstractions to make assigning shortcuts faster, but are actually implemented as two discrete actions that target the appropriate effects (e.g., `up` and `down`) of a widget. For example, assigning `E + pan` to a slider assignes `E + left` to the `down` action and `E + right` to the `up` action.

--- a/content/preferences-settings/shortcuts.md
+++ b/content/preferences-settings/shortcuts.md
@@ -192,7 +192,7 @@ The top panel of the shortcut mapping screen shows a list of available UI widget
 ---
 
 **Note:**
-You can **search** the top and bottom panels using the text entry boxes at the bottom of the screen, and use the **up/down** arrow keys to navigate between matches. 
+You can search the top and bottom panels using the text entry boxes at the bottom of the screen, and use the up/down arrow keys to navigate between matches. 
 
 ---
 

--- a/content/preferences-settings/shortcuts.md
+++ b/content/preferences-settings/shortcuts.md
@@ -40,6 +40,13 @@ For example:
 - The key `E` can be used to focus a module, or to toggle it on/off
 - The key `E`, combined with up/down movements or your pointing device, can be used to control the value of a slider
 
+---
+
+**Note:**
+By construction, a _continuous shortcut_ is sufficiently expressive to trigger a _discrete action_. The opposite is not true. However, it is possible to use a combination of two _discrete shortcuts_ to control a _continuous action_. For example, you can use two different shortcuts to trigger the `up` and `down` effects of a slider (see [anatomy of an action](#anatomy-of-an-action) below).
+
+---
+
 If you are using keyboard and mouse, **all shortcuts must start with one or more key presses**, as mouse actions in isolation are used to navigate and interact with the UI.
 
 If you have an external controller, you can trigger discrete actions by pressing one or more buttons on the controller. Continuous actions can use a combination of buttons and a knob/joystick movement, or just knob/joystick movement.
@@ -310,9 +317,3 @@ To see a list of _all_ of the default fallbacks, click the "enable fallbacks" ch
 Fallbacks are only applied if no other shortcut using the resulting combination has been explicitly created. In the above example, if you were to explicitly assign `Ctrl + R + left-click` to another action, the "enable/disable module" fallback would be ignored.
 
 Some fallback actions are defined using modifier keys (usually `Ctrl+` and `Shift+`). In this case you must define an initial shortcut without such a modifier in order to be able to use these fallbacks. For example, if you assign `Ctrl + R` to an action, you cannot use a `Ctrl+` fallback. Some default fallbacks of this type are provided for the _value_ element and for horizontal/vertical movements in the (zoomed) central area -- in this case, `Shift+` increases the speed to 10.0 and `Ctrl+` decreases the speed to 0.1.
-
-# implementation details
-
-This section covers some technical aspects that can be interesting for power users.
-
-**Continuous actions:** Continuous actions are convenience abstractions to make assigning shortcuts faster, but are actually implemented as two discrete actions that target the appropriate effects (e.g., `up` and `down`) of a widget. For example, assigning `E + pan` to a slider assignes `E + left` to the `down` action and `E + right` to the `up` action.

--- a/content/preferences-settings/shortcuts.md
+++ b/content/preferences-settings/shortcuts.md
@@ -5,10 +5,10 @@ weight: 120
 draft: false
 ---
 
-_Shortcuts_ are a way to control darktable using your keyboard, pointing device or external controller. They allow you to perform _actions_ without interacting directly with a UI element.
+_Shortcuts_ are a way to control darktable using your keyboard, mouse or trackpad and other input devices. They allow you to perform _actions_ without interacting directly with a UI element.
 
-An _action_ is usually (but not always) an operation that you might undertake using darktable's point-and-click user interface.
-See [common actions](#common-actions) below for a list of the most common ones. For example:
+An _action_ is usually an operation that you might undertake using darktable's point-and-click user interface.
+See [common actions](#common-actions) for a list of the most common ones. For example:
 
 -   Increase, decrease or reset sliders
 -   Scroll through dropdown lists
@@ -18,7 +18,9 @@ See [common actions](#common-actions) below for a list of the most common ones. 
 
 A _shortcut_ is a combination of inputs that triggers one of the actions available in a given context.
 
-Darktable comes with many predefined shortcuts that use a combination of key presses and mouse movements, but you can also use various other input devices, including MIDI devices and game controllers -- see the [midi device support](../special-topics/midi-device-support.md) section for details. These are referred to as _external devices_ or just _devices_ in this guide.
+Darktable comes with many predefined shortcuts using keyboard or keyboard and mouse, but you can also use various other input devices, including MIDI devices and game controllers -- see the [midi device support](../special-topics/midi-device-support.md) section for details. These are referred to as _input devices_ in this guide.
+
+The recommended way to assign shortcuts to visual elements is the [visual shortcut mapping](#visual-shortcut-mapping) mode.
 
 # types of actions and shortcuts
 
@@ -37,75 +39,82 @@ As the two action types are inherently different, so are the shortcuts you can u
 
 For example:
 
-- The key `E` can be used to focus a module, or to toggle it on/off
-- The key `E`, combined with up/down movements or your pointing device, can be used to control the value of a slider
+- The key `e` can be used to focus a module, or to toggle it on/off
+- The key `e`, combined with up/down movements or your pointing device, can be used to control the value of a slider
 
 ---
 
 **Note:**
-By construction, a _continuous shortcut_ is sufficiently expressive to trigger a _discrete action_. The opposite is not true. However, it is possible to use a combination of two _discrete shortcuts_ to control a _continuous action_. For example, you can use two different shortcuts to trigger the `up` and `down` effects of a slider (see [anatomy of an action](#anatomy-of-an-action) below).
+By construction, a _continuous shortcut_ is sufficiently expressive to trigger a _discrete action_. The opposite is not true. However, it is possible to use a combination of two _discrete shortcuts_ to control a _continuous action_. For example, you can use two different shortcuts to trigger the `up` and `down` effects of a slider (see [anatomy of an action](#anatomy-of-an-action)).
 
 ---
 
 If you are using keyboard and mouse, **all shortcuts must start with one or more key presses**, as mouse actions in isolation are used to navigate and interact with the UI.
 
-If you have an external controller, you can trigger discrete actions by pressing one or more buttons on the controller. Continuous actions can use a combination of buttons and a knob/joystick movement, or just knob/joystick movement.
+If you have an input device, you can trigger discrete actions by pressing one or more buttons on the controller. Continuous actions can use a combination of buttons and a knob/joystick movement, or just knob/joystick movement.
 
 # anatomy of a shortcut
 
-The simplest shortcut consists of just one key press (e.g., `E`).
+The simplest shortcut consists of just one key press (e.g., `e`).
 
-The same key can be repeated up to three times, so also `E + E` and `E + E + E` are valid, and distinct, shortcuts.
+The same key can be repeated up to three times, so also `e double-press` and `e triple-press` are valid, and distinct, shortcuts.
 
-You can further extend a shortcut with up to three clicks of different mouse buttons. So, `E + E + left-click` or `E + right-click + left-click` are also valid shortcuts.
+You can further extend a shortcut with up to three clicks of different mouse buttons. So, `e double-press + left click` or `e + right click + left click` are also valid shortcuts.
 
-Finally, if your fingers are very nimble and you really need to go there, you can repeat the last click up to three times. So, also `E + left-click + middle-click + middle-click` and `E + E + middle-click + left-click + right-click + right-click + right-click` are valid shortcuts.
+Finally, if your fingers are very nimble and you really need to go there, you can repeat the last click up to three times. So, also `e + left click + middle double-click` and `e double press + middle click + left click + right triple-click` are valid shortcuts.
 
 Hence, the most complex shortcut can consist of 8 key/button presses:
-* Three key presses of the same `key`, followed by
+* Three key presses of the same key, (e.g., `e`), followed by
 * Three presses of the three mouse buttons, followed by
 * 2 more repetitions of the last click.
 
-Your shortcut can include one or more modifiers (`Shift`, `Ctrl` and `Alt`). In this case, for a continuous shortcut, both the last key and the modifier must be pressed down when you execute the movement. For example, `Ctrl + E + E + pan` means that while moving the mouse left and/or right both  `E` and `Ctrl` must be pressed down.
+Your shortcut can include one or more modifiers (`shift`, `ctrl` and `alt`). In this case, for a continuous shortcut, both the last key and the modifier must be pressed down when you execute the movement. For example, `ctrl + e double-press + pan` means that while moving the mouse left and/or right both  `e` and `ctrl` must be pressed down.
 
 ---
 
 **Note:**
-If you are a MacOs user, your shortcuts will use `Cmd` instead of `Ctrl` and `Option` instead of `Alt`.
+If you are a MacOs user, your shortcuts will use `cmd` instead of `ctrl` and `option` instead of `alt`.
 
 ---
 
 If you are defining a continuous shortcut, then the movement part of the shortcut must be executed while the last key, mouse or controller button is held down.
 
-For example, the shortcut `E + E + pan`, can be activated by pressing `E` twice, holding down `E` on the second press and moving the mouse horizontally while the key is pressed.
+For example, the shortcut `e double-press + pan`, can be activated by pressing `e` twice, holding down `e` on the second press and moving the mouse horizontally while the key is pressed.
 
-**Short and long key presses.** 
-By default, all key presses in a shortcut are _short_, i.e., the key is pressed and immediately released. However, the last repetition of a key in a shortcut can also be a _long_ key press, defined as holding down the key for a bit longer than the duration of a double click. Hence `E + E` and `E + E(long)` are two distinct shortcuts that can be assigned to different actions. The associated action triggers when the key is released, which entails that a shortcut ending with a long press cannot be used for a continuos shortcut.
+## short and long key presses
 
-**Triggering multiple shortcuts at once.** 
-If both `E + mouse-scroll` and `F + mouse-scroll` are mapped to a slider (or if you have fallbacks enabled), then scrolling the mouse wheel while holding down both `E` and `F` will move both sliders.
-Similarly, you could map, say, `E + E + mouse-scroll` and `F + F + mouse-scroll` to two nodes in a graph (say, `yellow` and `green` in color equalizer). You can then use `E + E(hold) + F(hold) + mouse-scroll` to move both sliders at once. This works because the repeat key counter is per-shortcut, not per key, and it is reset only after the current shortcut ends (i.e., when the repeated key is released). Thus it is possible to trigger as many actions at once as your fingers can handle, provided that all the shortcuts involved have the same number of key presses (i.e., single, double or triple presses).
+By default, all key presses in a shortcut are _short_, i.e., the key is pressed and immediately released. However, the last repetition of a key in a shortcut can also be a _long_ key press, defined as holding down the key for a bit longer than the duration of a double click. Hence `e double-press` and `e long double-press` are two distinct shortcuts that can be assigned to different actions. The associated action triggers when the key is released, which entails that a shortcut ending with a long press cannot be used for a continuos shortcut.
 
-**Shortcuts must be unique within a view.**
-A single action may have multiple shortcuts but a single shortcut can only be linked to one action in a given darktable view -- you can't chain actions together except by applying a preset or style. You can, however, set up a single shortcut that does one thing in the lighttable view, say, and another in the darkroom view.
-
-**Additional modifiers.** As mentioned above, the only valid modifiers are the `Shift`, `Ctrl` and `Alt` keys on the keyboard. You can define additional keys (or device buttons) as modifiers by assigning keys/buttons to the "global/modifier" action. However, these will merely function as extra `Ctrl`, `Alt` or `Shift` keys -- you cannot create "new" modifiers.
-
-## defining continuous shortcuts
+## movements in continuous shortcuts
 
 The following movements are supported when defining continuous shortcuts:
 
 -   Movement of the mouse scroll wheel
 -   Horizontal, vertical or diagonal movement of the mouse cursor
--   Movement of a knob/joystick on an external device
+-   Movement of a knob/joystick on an input device
 
----
+When employing an input device, you can directly assign a control knob or joystick to an action. However, this will significantly reduce the flexibility of such devices, as you will be able to use the knob/joystick only to control one action. Conversely, by prefixing the movement with a key or button press you can use the same knob/joystick to control multiple actions.
 
-**Note:** You may need to switch off the "disable touchpad while typing" setting if you want to use continuous shortcuts with a laptop touchpad.
 
----
+## triggering multiple shortcuts at once
 
-As mentioned above, when employing an external device you can directly assign a control knob or joystick to an action. However, this will significantly reduce the flexibility of such devices, as you will be able to use the knob/joystick only to control one action. Conversely, by prefixing the movement with a key or button press you can use the same knob/joystick to control multiple actions.
+If both `e + scroll` and `f + scroll` are mapped to a slider (or if you have fallbacks enabled), then scrolling the mouse wheel while holding down both `e` and `f` will move both sliders.
+Similarly, you could map `e double-press + scroll` and `f double-press + scroll` to two nodes in a graph (say, `yellow` and `green` in color equalizer). You can then move both sliders at once by:
+
+1. pressing and releasing `e` once;
+2. pressing and holding `e`;
+3. pressing and holding `f`;
+4. using the scroll wheel while both `e` and `f` are pressed.
+
+This works because the repeat key counter is per-shortcut, not per key, and it is reset only after the current shortcut ends (i.e., when the repeated key is released). Thus it is possible to trigger as many actions at once as your fingers can handle, provided that all the shortcuts involved have the same number of key presses (i.e., single, double or triple presses).
+
+## shortcuts must be unique within a view
+
+A single action may have multiple shortcuts but a single shortcut can only be linked to one action in a given darktable view -- you can't chain actions together except by applying a preset or style. You can, however, set up a single shortcut that does one thing in the lighttable view and another in the darkroom view.
+
+## additional modifiers
+
+The only valid modifiers are the `shift`, `ctrl` and `alt` keys on the keyboard. You can assign any key (or input device buttons) to function as one of the existing modifier types by assigning keys/buttons to the "global/modifier" action. However, you cannot define new modifier types.
 
 # anatomy of an action
 
@@ -120,7 +129,7 @@ element
 effect
 : A shortcut can sometimes have multiple possible _effects_ on a given _element_. For example, a button can be activated as if it was pressed with a plain mouse-click or as if it was pressed with Ctrl+click. A slider's value can be edited, increased/decreased or reset.
 
-So, for example, you can assign the shortcut `E + mouse-scroll` to change the value (the _effect_) of the exposure slider (the _element_) of the exposure correction _widget_.
+So, for example, you can assign the shortcut `e + scroll` to change the value (the _effect_) of the exposure slider (the _element_) of the exposure correction _widget_.
 
 # assigning shortcuts to actions
 
@@ -143,7 +152,7 @@ The mouse cursor will change as you hover over UI widgets, to indicate whether o
 -   ![Don't signal](./shortcuts/no-signal.png#icon) indicates that there is no mappable widget under the cursor.
 
 **To define new shortcuts:**
-press a key combination while hovering over a mappable widget. A _default action_ will be assigned to that shortcut based on the type of widget and whether your shortcut includes a movement. See the [common actions](#common-actions) section below for examples of some of the defaults.
+press a key combination while hovering over a mappable widget. A _default action_ will be assigned to that shortcut based on the type of widget and whether your shortcut includes a movement. See the [common actions](#common-actions) section for examples of some of the defaults.
 You can assign as many shortcuts as you like in a single mapping session and then exit mapping mode when you are finished by clicking the ![visual mapping button](./shortcuts/visual-mapping-button.png#icon) icon again or right-clicking anywhere on the screen.
 
 **To explore already defined shortcuts:**
@@ -205,13 +214,13 @@ some actions may have no effect. For example, all sliders include a _button_ ele
 
 Actions in the "global" section of the shortcut mapping screen can be executed from any darktable view. Most of these actions do not have specific _elements_ as they are used to perform one-off operations.
 
-For example, the predefined shortcut `Tab` triggers the action `globals/panels/all`, which toggles the visibility of all the side panels in the current view.
+For example, the predefined shortcut `tab` triggers the action `globals/panels/all`, which toggles the visibility of all the side panels in the current view.
 
 ## view-specific actions
 
 Actions in the "views" section can only be executed from the specified darktable view. As with global actions, most do not have specific _elements_ as they are used to perform one-off operations.
 
-For example, the predefined shortcut `Ctrl + B` triggers the action `views/darktable/guide lines/toggle`, which toggles guide lines in the darktable view.
+For example, the predefined shortcut `ctrl + b` triggers the action `views/darktable/guide lines/toggle`, which toggles guide lines in the darktable view.
 
 ## actions on modules
 
@@ -245,7 +254,7 @@ If an action affects a processing module that can have multiple instances, you c
 
 Additional options are available in the shortcuts mapping screen to adjust the blend parameters (the \<blending\> section) and module controls (the \<focused\> section) for the currently-focused module. The latter section allows you to assign shortcuts to the first, second, third (etc.) button, drop-down, slider and tab on the module. The shortcuts will affect different module controls depending on which module currently has focus (as the available list of controls changes).
 
-For example, you if you assign `' + mouse-scroll` to `processing modules/\<focused\>/sliders` and set `element` to `1st`, you will be able to use the scroll wheel while holding down `'` to adjust the value of the first slider of the currently focused module. If `exposure` is focused you will affect the `exposure correction` slider, if `denoise (profiled)` is focused you will affect the `denoising strength` slider.
+For example, you if you assign `' + scroll` to `processing modules/\<focused\>/sliders` and set `element` to `1st`, you will be able to use the scroll wheel while holding down `'` to adjust the value of the first slider of the currently focused module. If `exposure` is focused you will affect the `exposure correction` slider, if `denoise (profiled)` is focused you will affect the `denoising strength` slider.
 
 ## actions on specific widget types
 
@@ -257,7 +266,7 @@ A button is a clickable icon in the darktable interface. The default action is t
 
 A toggle is a button that has a persistent on/off state. It therefore has additional _effects_ to allow you to toggle it or explicitly set its state. As with a normal button, the default action is to activate the toggle as if clicked with the left mouse button (which toggles the button on/off).
 
-For example, the predefined shortcut `Shift + O` is associated to `views/darkroom/raw overexposed/toggle`, which toggles on/off the raw overexposure indicator in the darkroom.
+For example, the predefined shortcut `shift + O` is associated to `views/darkroom/raw overexposed/toggle`, which toggles on/off the raw overexposure indicator in the darkroom.
 
 ### dropdowns
 
@@ -300,13 +309,13 @@ Fallbacks are a powerful way to quickly set up multiple actions using predefined
 
 ---
 
-If they are enabled, when you create a discrete shortcut (e.g., `Ctrl + R`) against a processing module the following shortcuts will be defined automatically:
+If they are enabled, when you create a discrete shortcut (e.g., `ctrl + r`) against a processing module the following shortcuts will be defined automatically:
 
--  `Ctrl + R` to show/hide the module (the default fallback)
--  `Ctrl + R + left-click` to enable/disable the module
--  `Ctrl + R + left-double-click` to reset the module
--  `Ctrl + R + right-click` to show the module's preset menu
--  `Ctrl + R + right-double-click` to show the module's multiple instance menu
+-  `ctrl + r` to show/hide the module (the default fallback)
+-  `ctrl + r + left click` to enable/disable the module
+-  `ctrl + r + left double-click` to reset the module
+-  `ctrl + r + right click` to show the module's preset menu
+-  `ctrl + r + right double-click` to show the module's multiple instance menu
 
 In each case (except the first) you should hold the initial shortcut while clicking with your mouse. The final single/double mouse-click will apply the corresponding action.
 
@@ -315,6 +324,6 @@ As with any other shortcut, fallback settings are fully customizable.
 
 To see a list of _all_ of the default fallbacks, click the "enable fallbacks" checkbox in the shortcut mapping screen and select the "fallbacks" category in the top panel. To see the fallbacks for a given widget (e.g. a slider) just select that widget in the top panel. In both cases an additional item (also named "fallbacks") will then appear in the bottom panel containing full details of the available fallbacks.
 
-Fallbacks are only applied if no other shortcut using the resulting combination has been explicitly created. In the above example, if you were to explicitly assign `Ctrl + R + left-click` to another action, the "enable/disable module" fallback would be ignored.
+Fallbacks are only applied if no other shortcut using the resulting combination has been explicitly created. In the above example, if you were to explicitly assign `ctrl + r + left click` to another action, the "enable/disable module" fallback would be ignored.
 
-Some fallback actions are defined using modifier keys (usually `Ctrl+` and `Shift+`). In this case you must define an initial shortcut without such a modifier in order to be able to use these fallbacks. For example, if you assign `Ctrl + R` to an action, you cannot use a `Ctrl+` fallback. Some default fallbacks of this type are provided for the _value_ element and for horizontal/vertical movements in the (zoomed) central area -- in this case, `Shift+` increases the speed to 10.0 and `Ctrl+` decreases the speed to 0.1.
+Some fallback actions are defined using modifier keys (usually `ctrl +` and `shift +`). In this case you must define an initial shortcut without such a modifier in order to be able to use these fallbacks. For example, if you assign `ctrl + r` to an action, you cannot use a `ctrl +` fallback. Some default fallbacks of this type are provided for the _value_ element and for horizontal/vertical movements in the (zoomed) central area -- in this case, `shift +` increases the speed to 10.0 and `ctrl +` decreases the speed to 0.1.

--- a/content/preferences-settings/shortcuts.md
+++ b/content/preferences-settings/shortcuts.md
@@ -90,7 +90,7 @@ Your shortcut can include one or more modifiers (`shift`, `ctrl` and `alt`). In 
 ---
 
 **Note:**
-If you are a MacOs user, your shortcuts will use `cmd` instead of `ctrl` and `option` instead of `alt`.
+If you are a macOS user, your shortcuts will use `cmd` instead of `ctrl` and `option` instead of `alt`.
 
 ---
 

--- a/content/preferences-settings/shortcuts.md
+++ b/content/preferences-settings/shortcuts.md
@@ -264,7 +264,7 @@ _enable_
 : Acts as a _toggle_ that switches the module on and off.
 
 _focus_
-: Acts as a _toggle_ that focuses or de-focuses the module. This is useful for modules such as [_crop_](../module-reference/processing-modules/crop.md) or [_tone equalizer_](../module-reference/processing-modules/tone-equalizer.md), whose on-screen controls are only activated when those modules have focus. For _crop_, changes are saved only when the module loses focus.
+: Acts as a _toggle_ that focuses or unfocuses the module. This is useful for modules such as [_crop_](../module-reference/processing-modules/crop.md) or [_tone equalizer_](../module-reference/processing-modules/tone-equalizer.md), whose on-screen controls are only activated when those modules have focus. For _crop_, changes are saved only when the module loses focus.
 
 _instance_
 : Allows you to select actions from the [multiple-instance](../darkroom/processing-modules/multiple-instances.md) menu (e.g. move up/down, create new instance). The discrete action associated to the _instance_ element displays a list of the available options for selection; a directional action is also available and will move the _preferred module instance_ (see below) up and down the pixelpipe.

--- a/content/preferences-settings/shortcuts.md
+++ b/content/preferences-settings/shortcuts.md
@@ -80,7 +80,7 @@ If you are defining a continuous shortcut, then the movement part of the shortcu
 For example, the shortcut `E + E + pan`, can be activated by pressing `E` twice, holding down `E` on the second press and moving the mouse horizontally while the key is pressed.
 
 **Short and long key presses.** 
-By default, all key presses in a shortcut are _short_, i.e., the key is pressed and immediately released. However, the last repetition of a key in a shortcut can also be a _long_ keypress, defined as holding down the key for a bit longer than the duration of a double click. Hence `E + E` and `E + E(long)` are two distinct shortcuts that can be assigned to different actions. The associated action triggers when the key is released, which entails that a shortcut ending with a long press cannot be used for a continuos shortcut.
+By default, all key presses in a shortcut are _short_, i.e., the key is pressed and immediately released. However, the last repetition of a key in a shortcut can also be a _long_ key press, defined as holding down the key for a bit longer than the duration of a double click. Hence `E + E` and `E + E(long)` are two distinct shortcuts that can be assigned to different actions. The associated action triggers when the key is released, which entails that a shortcut ending with a long press cannot be used for a continuos shortcut.
 
 **Triggering multiple shortcuts at once.** 
 If both `E + mouse-scroll` and `F + mouse-scroll` are mapped to a slider (or if you have fallbacks enabled), then scrolling the mouse wheel while holding down both `E` and `F` will move both sliders.

--- a/content/preferences-settings/shortcuts.md
+++ b/content/preferences-settings/shortcuts.md
@@ -5,7 +5,7 @@ weight: 120
 draft: false
 ---
 
-_Shortcuts_ are a way to control darktable using your keyboard, mouse, trackpad, or other input devices. They allow you to perform _actions_ without interacting directly with a UI element.
+_Shortcuts_ are a way to control darktable using your keyboard, mouse, trackpad, or other _input devices_, such as MIDI and game controllers (as detailed in the [midi device support](../special-topics/midi-device-support.md) section). They allow you to perform _actions_ without interacting directly with a UI element.
 
 An _action_ is usually an operation that you might undertake using darktable's point-and-click user interface.
 See [common actions](#common-actions) for a list of the most common ones. For example:
@@ -15,10 +15,6 @@ See [common actions](#common-actions) for a list of the most common ones. For ex
 -   Enable, expand or focus modules
 -   Click buttons
 -   Switch between views
-
-A _shortcut_ is a combination of inputs that triggers one of the actions available in a given context.
-
-Darktable comes with many predefined shortcuts using keyboard or keyboard and mouse, but you can also use various other input devices, including MIDI devices and game controllers -- see the [midi device support](../special-topics/midi-device-support.md) section for details. These are referred to as _input devices_ in this guide.
 
 The recommended way to assign shortcuts to visual elements is the [visual shortcut mapping](#visual-shortcut-mapping) mode.
 

--- a/content/preferences-settings/shortcuts.md
+++ b/content/preferences-settings/shortcuts.md
@@ -5,66 +5,10 @@ weight: 120
 draft: false
 ---
 
-You can perform almost any action in darktable with a keyboard/mouse shortcut. You can also use various other input devices, including MIDI devices and game controllers -- see the [midi device support](../special-topics/midi-device-support.md) section for details. These are referred to as _external devices_ or just _devices_ in this guide.
+_Shortcuts_ are a way to control darktable using your keyboard, pointing device or external controller. They allow you to perform _actions_ without interacting directly with a UI element.
 
-# defining shortcuts
-
-A _shortcut_ is a combination of key or button presses and/or mouse or device movements that performs an _action_ in darktable.
-
-The recommended way to assign shortcuts to visual elements is the [visual shortcut mapping](#visual-shortcut-mapping) mode.
-
-A single action may have multiple shortcuts but a single shortcut can only be linked to one action in a given darktable view -- you can't chain actions together except by applying a preset or style. You can, however, set up a single shortcut that does one thing in the lighttable view, say, and another in the darkroom view.
-
-## initiating a shortcut
-
-A shortcut must be initiated by either
-
--   pressing a key on the keyboard; or
--   pressing a button or moving a knob/joystick on an external device
-
-You cannot initiate a shortcut by moving your mouse, or by pressing the left, right or middle mouse buttons, as these actions are used to interact with darktable's UI.
-
-## simple shortcuts
-
-A shortcut that only includes button and/or key presses (and not mouse/device movements) is referred to as a _simple_ shortcut.
-
-A simple shortcut must be initiated as above, but can include:
-
--   One or more modifier keys (Shift, Ctrl, Alt), held down while executing the remainder of the shortcut
--   Up to three key presses, the last one of which may be a long-press (defined as a key-press longer than your system's double-click duration)
--   Similarly, up to three device-button presses or mouse-button clicks, the last of which may be long
-
-Various combinations of keyboard, mouse, and device buttons can be used to create simple shortcuts.
-
-### creating additional modifiers
-
-The only valid modifiers are the Shift, Ctrl and Alt keys on the keyboard. You can define additional keys (or device buttons) as modifiers by assigning keys/buttons to the "global/modifier" action. However, these will merely function as extra Ctrl, Alt or Shift keys -- you cannot create "new" modifiers.
-
-## extending simple shortcuts with movement
-
-For certain actions you can choose to _extend_ a simple shortcut using mouse/device movement. For example you might hold Ctrl+X while scrolling with your mouse to change the value of a slider. The following can be used to extend a simple shortcut:
-
--   Movement of the mouse scroll wheel
--   Horizontal, vertical or diagonal movement of the mouse cursor
--   Movement of a knob/joystick on an external device
-
-To extend a simple shortcut, you must hold the final key/button of the simple shortcut while performing the extending mouse/device movement.
-
-For external devices you do not need to start with a _simple_ shortcut -- you can directly assign a control knob or joystick to an action -- though this will significantly reduce the flexibility of such devices.
-
-Long button and key presses cannot be extended, as the length of the click/press is timed using the release of the final button/key -- such shortcuts must be terminated with the raising of the final button/key.
-
----
-
-**Note:** You may need to switch off the "disable touchpad while typing" setting if you want to use extended shortcuts with a laptop touchpad.
-
----
-
-# actions
-
-Shortcuts are used to initiate _actions_ within darktable.
-
-An _action_ is usually (but not always) an operation that you might undertake using darktable's point-and-click user interface. For example:
+An _action_ is usually (but not always) an operation that you might undertake using darktable's point-and-click user interface.
+See [common actions](#common-actions) below for a list of the most common ones. For example:
 
 -   Increase, decrease or reset sliders
 -   Scroll through dropdown lists
@@ -72,10 +16,74 @@ An _action_ is usually (but not always) an operation that you might undertake us
 -   Click buttons
 -   Switch between views
 
-Such point-and-click type _actions_ are normally defined as the application of an _effect_ to an _element_ of a _widget_, where these terms are defined as follows:
+A _shortcut_ is a combination of inputs that triggers one of the actions available in a given context.
+
+Darktable comes with many predefined shortcuts that use a combination of key presses and mouse movements, but you can also use various other input devices, including MIDI devices and game controllers -- see the [midi device support](../special-topics/midi-device-support.md) section for details. These are referred to as _external devices_ or just _devices_ in this guide.
+
+# types of actions and shortcuts
+
+There are two types of actions:
+
+_Discrete_ actions
+: E.g., executing a command, focusing a UI element or resetting a slider
+
+_Continuous actions_
+: E.g., adjusting the value of a slider or scrolling through a list of presets
+
+As the two action types are inherently different, so are the shortcuts you can use to trigger them:
+
+- _Discrete actions_ can be triggered by _discrete shortcuts_ consisting only of key presses and optionally mouse clicks
+- _Continuous actions_ need also a direction (and, in the case of sliders, a magnitude). Hence, the corresponding _continuous shortcuts_ will also incorporate a mouse movement
+
+For example:
+
+- The key `e` can be used to focus a module, or to toggle it on/off
+- The key `e`, combined with up/down movements or your pointing device, can be used to control the value of a slider 
+
+If you are using keyboard and mouse, **all shortcuts must start with one or more key presses**, as mouse actions in isolation are used to navigate and interact with the UI.
+
+If you have an external controller, you can trigger discrete actions by pressing one or more buttons on the controller. Continuous actions can use a combination of buttons and a knob/joystick movement, or just knob/joystick movement.
+
+# anatomy of a shortcut
+
+Shortcuts can consist of up to three key/button presses **of the same key/button** (in a quick sequence).
+So, for example, `E`, `E + E` and `E + E + E` are all valid shortcuts to trigger discrete actions, as well as `E + left-click`, `E + right-click` or `E + E + left-click`.
+
+On the contrary, `E + A` is not a valid shortcut, and darktable will interpret it as a two different shortcuts: `E` followed by `A`.
+
+Your shortcut can include one or more modifiers (`Shift`, `Ctrl/Cmd` and `Alt/Option`). In this case, the modifier(s) have to be held down while executing the remainder of the shortcut. So, `Ctrl + E + E` means holding down `Ctrl` while pressing `E` twice in a rapid sequence.
+
+If you are defining a continuous shortcut, then the movement part of the shortcut must be executed while the last key, mouse or controller button is held down.
+
+For example, the shortcut `E + E + pan`, can be activated by pressing `E` twice, holding down `E` on the second press and moving the mouse horizontally. While you are holding down `E`, moving the mouse horizontally will adjust the value associated with the shortcut's action. As you release the `E` key, moving the mouse horizontally will just move the mouse on the screen.
+
+**Shortcuts must be unique within a view.**
+A single action may have multiple shortcuts but a single shortcut can only be linked to one action in a given darktable view -- you can't chain actions together except by applying a preset or style. You can, however, set up a single shortcut that does one thing in the lighttable view, say, and another in the darkroom view.
+
+**Additional modifiers.** As mentioned above, the only valid modifiers are the Shift, Ctrl/Cmd and Alt/Option keys on the keyboard. You can define additional keys (or device buttons) as modifiers by assigning keys/buttons to the "global/modifier" action. However, these will merely function as extra Ctrl, Alt or Shift keys -- you cannot create "new" modifiers.
+
+## defining continuous shortcuts
+
+The following movements are supported when defining continuous shortcuts:
+
+-   Movement of the mouse scroll wheel
+-   Horizontal, vertical or diagonal movement of the mouse cursor
+-   Movement of a knob/joystick on an external device
+
+---
+
+**Note:** You may need to switch off the "disable touchpad while typing" setting if you want to use continuous shortcuts with a laptop touchpad.
+
+---
+
+As mentioned above, when employing an external device you can directly assign a control knob or joystick to an action. However, this will significantly reduce the flexibility of such devices, as you will be able to use the knob/joystick only to control one action. Conversely, by prefixing the movement with a key or button press you can use the same knob/joystick to control multiple actions.
+
+# anatomy of an action
+
+_Actions_ apply an _effect_ to an _element_ of a _widget_, where these terms are defined as follows:
 
 widget
-: Each visible part of the user interface is known as a _widget_. For example the darktable application window is a widget, containing side panel widgets, each of which contains module widgets, each of which contains button, slider and dropdown list widgets etc... When assigning a shortcut to an action, you must first decide which widget it is to be applied to.
+: Each visible part of the user interface is a _widget_. For example, the darktable application window is a widget, containing side panel widgets, each of which contains module widgets, each of which contains button, slider and dropdown list widgets etc. When assigning a shortcut to an action, you must first decide which widget it will apply to.
 
 element
 : An _element_ is the part of a UI widget that is affected by your shortcut. For example, for a slider that has a [picker](../darkroom/processing-modules/module-controls.md#pickers), you can make a shortcut activate the picker _button_ element or change the _value_ element of the slider. For a row of tabs (the row is a single widget) you can select which tab element to activate or use your mouse scroll wheel to scroll through the tabs.
@@ -83,9 +91,11 @@ element
 effect
 : A shortcut can sometimes have multiple possible _effects_ on a given _element_. For example, a button can be activated as if it was pressed with a plain mouse-click or as if it was pressed with Ctrl+click. A slider's value can be edited, increased/decreased or reset.
 
+So, for example, you can assign the shortcut `E + mouse-scroll` to change the value (the _effect_) of the exposure slider (the _element_) of the exposure correction _widget_.
+
 # assigning shortcuts to actions
 
-There are two primary methods of assigning a shortcut to an action.
+There are two primary methods of assigning shortcuts to actions: [visual shortcut mapping](#visual-shortcut-mapping) (recommended) and the [shortcut mapping screen](#shortcut-mapping-screen). The former makes it easier to remap multiple shortcuts at once, while the latter allows for finer control and more flexibility. Both options are detailed below.
 
 ## visual shortcut mapping
 
@@ -103,23 +113,34 @@ The mouse cursor will change as you hover over UI widgets, to indicate whether o
 
 -   ![Don't signal](./shortcuts/no-signal.png#icon) indicates that there is no mappable widget under the cursor.
 
-Press a key combination while hovering over a mappable widget to assign a shortcut to that widget -- a default action will be assigned to that shortcut based on the type of widget and whether you have keyed a _simple_ or _extended_ shortcut. See below for details of some of the default assigned actions.
-
-Left-click on a mappable widget to open the shortcut mapping screen for that widget (see below). Left-click anywhere else on the screen to open the shortcut mapping screen, expanded (where possible) based on the part of the screen you have clicked on. This screen can be used to alter the action assigned to a shortcut and to configure shortcuts for non-visual actions. Entering the shortcut mapping screen exits visual shortcut mapping mode.
-
+**To define new shortcuts:**
+press a key combination while hovering over a mappable widget. A _default action_ will be assigned to that shortcut based on the type of widget and whether your shortcut includes a movement. See the [common actions](#common-actions) section below for examples of some of the defaults.
 You can assign as many shortcuts as you like in a single mapping session and then exit mapping mode when you are finished by clicking the ![visual mapping button](./shortcuts/visual-mapping-button.png#icon) icon again or right-clicking anywhere on the screen.
 
-You can delete a user-defined shortcut mapping by defining it a second time against the same widget. If you attempt to reallocate an existing shortcut to a new action, you will be notified of the conflict and asked whether you wish to replace the existing shortcut.
+**To explore already defined shortcuts:**
+left-click on a mappable widget to open the shortcut mapping screen for that widget (see below). Left-click anywhere else on the screen to open the shortcut mapping screen, expanded (where possible) based on the part of the screen you have clicked on. This screen can be used to alter the action assigned to a shortcut and to configure shortcuts for non-visual actions. Entering the shortcut mapping screen exits visual shortcut mapping mode.
 
-Finally, if you scroll with your mouse wheel while in visual mapping mode (without pressing any other buttons/keys) when hovering over a slider, this will change the default speed for that slider -- scroll up to increase and down to decrease. When you leave mapping mode, normal mouse scrolls over that slider will change its value with the adjusted speed.
+**To update existing shortcuts:**
+define a second shortcut against the same widget. If you attempt to reallocate an existing shortcut to a new action, you will be notified of the conflict and prompted to replace the existing shortcut.
+
+**To change the default speed of a slider:**
+scroll with your mouse wheel while in visual mapping mode (without pressing any other buttons/keys) when hovering over the slider -- scroll up to increase and down to decrease. When you leave mapping mode, normal mouse scrolls over that slider will change its value with the adjusted speed.
 
 ## shortcut mapping screen
 
-The most flexible way to create shortcuts is by using the shortcut mapping screen, which can be accessed from the global preferences dialog or by left-clicking in visual mapping mode. This screen allows access to all available actions, including some that are not directly linked to a UI widget.
+The shortcut mapping screen can be accessed from the global preferences dialog or by right-clicking on the visual mapping button. This screen allows access to all available actions, including some that are not directly linked to a UI widget.
 
-The top panel of the shortcut mapping screen shows a list of available UI widgets/actions and the bottom panel shows the shortcuts currently assigned to them. You can search the top and bottom panels using the text entry boxes at the bottom of the screen (use the up/down arrow keys to navigate between matches). Fields that can be changed by user action are shown in bold.
+The top panel of the shortcut mapping screen shows a list of available UI widgets/actions and the bottom panel shows the shortcuts currently assigned to them. Fields that can be changed by user action are shown in bold.
 
-Double-click an item in the top panel to create a new shortcut for that item, and then enter your desired shortcut (right-click to cancel). Once you have done this, a new entry will appear in the bottom panel showing the shortcut you have created. You can then manually alter the _element_, _effect_, _speed_ or _instance_ of the assigned action against that shortcut in the bottom panel. To delete a user-defined shortcut, select it in the bottom panel and press the Delete key.
+---
+
+**Note:**
+You can **search** the top and bottom panels using the text entry boxes at the bottom of the screen, and use the **up/down** arrow keys to navigate between matches. 
+
+---
+
+**To create a new shortcut for an item:**
+Double-click an item in the top panel, and then enter your desired shortcut (right-click to cancel). Once you have done this, a new entry will appear in the bottom panel showing the shortcut you have created. You can then manually alter the _element_, _effect_, _speed_ or _instance_ of the assigned action against that shortcut in the bottom panel. To delete a user-defined shortcut, select it in the bottom panel and press the Delete key.
 
 Selecting an existing shortcut in the bottom panel will highlight (in bold) the matching action and its parents in the top panel. You can use this to navigate the top panel and find related actions.
 
@@ -142,29 +163,30 @@ Alternatively, you may disable [preferences > miscellaneous > interface > load d
 
 # common actions
 
-The following is a list of some of the actions to which you can assign shortcuts, organized by widget type. This is not an exhaustive list and you are encouraged to browse the shortcut mapping screen for a complete list of available actions. If you assign a shortcut to a widget, it will be given a default action, depending on the type of widget and on whether you have assigned a simple or extended shortcut.
+The following is a list of some of the actions to which you can assign shortcuts, organized by widget type. This is not an exhaustive list and you are encouraged to browse the shortcut mapping screen for a complete list of available actions.
 
-Note that it is possible to assign a number of actions that have no effect. For example, all sliders include a _button_ element, regardless of whether such a button is actually present alongside a given slider.
+---
 
-## global
+**Note:**
+some actions may have no effect. For example, all sliders include a _button_ element, regardless of whether such a button is actually present alongside a given slider.
+
+---
+
+## global actions
 
 Actions in the "global" section of the shortcut mapping screen can be executed from any darktable view. Most of these actions do not have specific _elements_ as they are used to perform one-off operations.
 
-## views
+For example, the predefined shortcut `Tab` triggers the action `globals/panels/all`, which toggles the visibility of all the side panels in the current view.
+
+## view-specific actions
 
 Actions in the "views" section can only be executed from the specified darktable view. As with global actions, most do not have specific _elements_ as they are used to perform one-off operations.
 
-## buttons
+For example, the predefined shortcut `Ctrl/Cmd + B` triggers the action `views/darktable/guide lines/toggle`, which toggles guide lines in the darktable view.
 
-A button is a clickable icon in the darktable interface. The default action, when assigning a simple shortcut to a _button_, is to activate that button as if clicked with the left mouse button. You can modify this action to activate the button as if clicked while holding a modifier key.
+## actions on modules
 
-## toggles
-
-A toggle is a button that has a persistent on/off state. It therefore has additional _effects_ to allow you to toggle it or explicitly set its state. As with a normal button the default action, when assigning a simple shortcut to a toggle, is to activate the toggle as if clicked with the left mouse button (which toggles the button on/off).
-
-## utility modules
-
-All utility modules have the following elements:
+All _utility_ and _processing_ modules have the following elements:
 
 _show_
 : Acts as a _toggle_ that expands and collapses the module.
@@ -173,15 +195,13 @@ _reset_
 : Acts as a _button_ that resets all module parameters when activated. The _ctrl-activate_ action can be used to re-apply any automatic presets for that module.
 
 _presets_
-: Allows you to select actions from the [presets](../darkroom/processing-modules/presets.md) menu (e.g. edit, update, previous, next). The default action, when assigning a simple shortcut to a _preset_ element, is to display a list of the available presets for selection. Extended shortcuts are not currently available for preset elements.
+: Allows you to select actions from the [presets](../darkroom/processing-modules/presets.md) menu (e.g. edit, update, previous, next). The default action, when assigning a discrete shortcut to a _preset_ element, is to display a list of the available presets for selection.
 
-The default action, when assigning a simple shortcut to a utility module, is to _toggle_ the _show_ element (expand/collapse the module).
+When a shortcut is assigned to a utility module, the default action is to _toggle_ the _show_ element (expand/collapse the module).
 
-In addition, shortcuts are available for all of the controls on each module as well as any stored presets (see below).
+### processing modules
 
-## processing modules
-
-Processing modules have the same elements and defaults as utility modules with the following additional elements:
+Additionally, processing modules have the following elements:
 
 _enable_
 : Acts as a _toggle_ that switches the module on and off.
@@ -190,30 +210,42 @@ _focus_
 : Acts as a _toggle_ that focuses or defocuses the module. This is useful for modules such as [_crop_](../module-reference/processing-modules/crop.md) or [_tone equalizer_](../module-reference/processing-modules/tone-equalizer.md), whose on-screen controls are only activated when those modules have focus. For _crop_, changes are saved only when the module loses focus.
 
 _instance_
-: Allows you to select actions from the [multiple-instance](../darkroom/processing-modules/multiple-instances.md) menu (e.g. move up/down, create new instance). The default action, when assigning a simple shortcut to the _instance_ element, is to display a list of the available options for selection; An extended shortcut will move the _preferred module instance_ (see below) up and down the pixelpipe.
+: Allows you to select actions from the [multiple-instance](../darkroom/processing-modules/multiple-instances.md) menu (e.g. move up/down, create new instance). The discrete action associated to the _instance_ element displays a list of the available options for selection; a continuous action is also available and will move the _preferred module instance_ (see below) up and down the pixelpipe.
 
 If an action affects a processing module that can have multiple instances, you can choose which instance to adjust with a given shortcut. By default, all actions will affect the "preferred" instance, as defined using the settings in [preferences > miscellaneous > shortcuts with multiple instances](./miscellaneous.md#shortcuts-with-multiple-instances).
 
 Additional options are available in the shortcuts mapping screen to adjust the blend parameters (the \<blending\> section) and module controls (the \<focused\> section) for the currently-focused module. The latter section allows you to assign shortcuts to the first, second, third (etc.) button, drop-down, slider and tab on the module. The shortcuts will affect different module controls depending on which module currently has focus (as the available list of controls changes).
 
-You can also assign scroll shortcuts to the 'preset' menu, which allows you to use your mouse scroll wheel to scroll through the module's presets.
+For example, you if you assign `' + mouse-scroll` to `processing modules/\<focused\>/sliders` and set `element` to `1st`, you will be able to use the scroll wheel while holding down `'` to adjust the value of the first slider of the currently focused module. If `exposure` is focused you will affect the `exposure correction` slider, if `denoise (profiled)` is focused you will affect the `denoising strength` slider.
 
-## dropdowns
+## actions on specific widget types
+
+### buttons
+
+A button is a clickable icon in the darktable interface. The default action is to activate that button as if clicked with the left mouse button. You can modify this action to activate the button as if clicked while holding a modifier key.
+
+### toggles
+
+A toggle is a button that has a persistent on/off state. It therefore has additional _effects_ to allow you to toggle it or explicitly set its state. As with a normal button, the default action is to activate the toggle as if clicked with the left mouse button (which toggles the button on/off).
+
+For example, the predefined shortcut `Shift + O` is associated to `views/darkroom/raw overexposed/toggle`, which toggles on/off the raw overexposure indicator in the darkroom.
+
+### dropdowns
 
 A dropdown is a multi-selection box and has the following elements available:
 
 _selection_
-: Allows values to be selected from the dropdown list in various ways. The default action, when assigning a simple shortcut to a dropdown, is to display a popup _edit_ box with a list of the available values for selection; An extended shortcut (including a mouse movement) will scroll through the available values.
+: Allows values to be selected from the dropdown list in various ways. The default action, when assigning a discrete shortcut to a dropdown, is to display a popup _edit_ box with a list of the available values for selection; A continuous shortcut (i.e., including a mouse movement) will scroll through the available values.
 
 _button_
 : A standard _button_ element that allows the button to the right of the dropdown (if present) to be activated. For example, the _aspect_ dropdown in the [_crop_](../module-reference/processing-modules/crop.md) module has a button that allows the crop controls to be changed from portrait to landscape and vice versa.
 
-## sliders
+### sliders
 
 A slider allows you to continuously alter an integer or decimal value, and has the following elements available:
 
 _value_
-: Allows the current value of the slider to be altered. The default action, when assigning a simple shortcut to a slider, is to display a popup _edit_ box so you can enter a value; An extended shortcut (including a mouse movement) will change the value up and down. Value elements are also used for modifying some on-screen graphs. When modifying the _value_ element with a shortcut you may not exceed the bounds set in the visual slider.
+: Allows the current value of the slider to be altered. The default action, when assigning a discrete shortcut to a slider, is to display a popup _edit_ box so you can enter a value; A continuous shortcut will change the value up and down. Value elements are also used for modifying some on-screen graphs. When modifying the _value_ element with a shortcut you may not exceed the bounds set in the visual slider.
 
 _force_
 : This is the same as the _value_ element described above, but it allows you to exceed the bounds set in the visual slider.
@@ -226,26 +258,34 @@ _button_
 
 You can alter the value of a slider more quickly or slowly than normal by defining the _speed_ of the action in the shortcut mapping screen. By default a _value_ (or _force_) effect is given a speed of 1.0, which means that it is changed at the default rate defined by the given slider. You can alter the slider more quickly by increasing the speed (a speed of 10 makes the action 10x faster) or more slowly by decreasing it (a speed of 0.1 makes the action 10x slower).
 
-# fallbacks
+# fallbacks (a.k.a. generalized shortcut extensions)
 
-Where a _widget_ can have multiple different _actions_ applied to it, it can be tedious to set up individual shortcuts for each one of those actions. To make this process simpler, if you create a simple shortcut a number of effects can be made available by default as extensions to that shortcut. These are known as _fallbacks_.
+As discussed above, a _widget_ can have multiple different _actions_ applied to it, and you may want to set shortcuts to control several of them. For example, to toggle a module on/off, expand/collapse it, and reset it to its default state. Normally, this would require setting 3 shortcuts for each module. If you want to control 5 modules in this fashion, you have to define 15 shortcuts. Setting up all these shortcuts one by one can be tedious and error prone.
 
-While fallbacks are a powerful way to quickly set up multiple actions using predefined and consistent shortcuts, they will assign a lot of actions automatically (which might not be what you want), and can be hard to understand. Fallbacks are therefore disabled by default and you will need to click on the "enable fallbacks" check box in the shortcuts setup window to enable them.
+To make this process simpler and to ensure consistency across all modules, you can create a single discrete shortcut for each module and then have a number of effects made available by default as _extensions_ to that shortcut. These _generalized shortcut extensions_ are called shortcut _fallbacks_.
 
-To take a brief example, you could create a simple shortcut (e.g. Ctrl+R) against a processing module. This will automatically set up the following _fallback_ effects using the defined shortcut, extended with mouse-clicks. In each case (except the first) you should hold the initial shortcut while clicking with your mouse. The final mouse-click will apply the action defined below:
+---
 
--   Ctrl+R (no mouse-click) to show/hide the module (the default fallback)
--   Ctrl+R+left-click to enable/disable the module
--   Ctrl+R+left-double-click to reset the module
--   Ctrl+R+right-click to show the module's preset menu
--   Ctrl+R+right-double-click to show the module's multiple instance menu
+**Note:**
+Fallbacks are a powerful way to quickly set up multiple actions using predefined and consistent shortcuts. They will assign a lot of actions automatically, which may be confusing if you are not aware of them. Fallbacks are therefore _disabled_ by default and you will need to click on the `enable fallbacks` check box in the shortcuts setup window to enable them.
 
-Similar fallbacks are defined for many common UI elements and all can be manually overridden.
+---
 
-Some fallback actions are defined using modifier keys (usually `Ctrl+` and `Shift+`). In this case you must define an initial shortcut without such a modifier in order to be able to use these fallbacks. For example, if you assign Ctrl+R to an action, you cannot use a `Ctrl+` fallback. Some default fallbacks of this type are provided for the _value_ element and for horizontal/vertical movements in the (zoomed) central area -- in this case, `Shift+` increases the speed to 10.0 and `Ctrl+` decreases the speed to 0.1.
+If they are enabled, when you create a discrete shortcut (e.g., `Ctrl + R`) against a processing module the following shortcuts will be defined automatically:
+
+-  `Ctrl + R` to show/hide the module (the default fallback)
+-  `Ctrl + R + left-click` to enable/disable the module
+-  `Ctrl + R + left-double-click` to reset the module
+-  `Ctrl + R + right-click` to show the module's preset menu
+-  `Ctrl + R + right-double-click` to show the module's multiple instance menu
+
+In each case (except the first) you should hold the initial shortcut while clicking with your mouse. The final single/double mouse-click will apply the corresponding action.
+
+Similar fallbacks are defined for many common UI elements.
+As with any other shortcut, fallback settings are fully customizable.
 
 To see a list of _all_ of the default fallbacks, click the "enable fallbacks" checkbox in the shortcut mapping screen and select the "fallbacks" category in the top panel. To see the fallbacks for a given widget (e.g. a slider) just select that widget in the top panel. In both cases an additional item (also named "fallbacks") will then appear in the bottom panel containing full details of the available fallbacks.
 
-Fallbacks are only applied if no other shortcut using that combination has been explicitly created. In the above example, if you were to explicitly assign Ctrl+R+left-click to another action, the "enable/disable module" fallback would be ignored.
+Fallbacks are only applied if no other shortcut using the resulting combination has been explicitly created. In the above example, if you were to explicitly assign `Ctrl + R + left-click` to another action, the "enable/disable module" fallback would be ignored.
 
-As with any other shortcut, fallback settings are fully customizable.
+Some fallback actions are defined using modifier keys (usually `Ctrl+` and `Shift+`). In this case you must define an initial shortcut without such a modifier in order to be able to use these fallbacks. For example, if you assign `Ctrl + R` to an action, you cannot use a `Ctrl+` fallback. Some default fallbacks of this type are provided for the _value_ element and for horizontal/vertical movements in the (zoomed) central area -- in this case, `Shift+` increases the speed to 10.0 and `Ctrl+` decreases the speed to 0.1.

--- a/content/preferences-settings/shortcuts.md
+++ b/content/preferences-settings/shortcuts.md
@@ -66,7 +66,7 @@ Hence, the most complex shortcut can consist of 8 key/button presses:
 * Three presses of the three mouse buttons, followed by
 * 2 more repetitions of the last click.
 
-Your shortcut can include one or more modifiers (`Shift`, `Ctrl` and `Alt`). In this case, the modifier(s) have to be held down while executing the remainder of the shortcut. So, `Ctrl + E + E` means holding down `Ctrl` while pressing `E` twice in a rapid sequence.
+Your shortcut can include one or more modifiers (`Shift`, `Ctrl` and `Alt`). In this case, for a continuous shortcut, both the last key and the modifier must be pressed down when you execute the movement. For example, `Ctrl + E + E + pan` means that while moving the mouse left and/or right both  `E` and `Ctrl` must be pressed down.
 
 ---
 

--- a/content/preferences-settings/shortcuts.md
+++ b/content/preferences-settings/shortcuts.md
@@ -108,7 +108,7 @@ The following movements are supported when defining directional shortcuts:
 -   Horizontal, vertical or diagonal movement of the mouse cursor
 -   Movement of a knob/joystick on an input device
 
-When employing an input device, you can directly assign a control knob or joystick to an action. However, this will significantly reduce the flexibility of such devices, as you will be able to use the knob/joystick only to control one action. Conversely, by prefixing the movement with a key or button press you can use the same knob/joystick to control multiple actions.
+When using an input device, you can directly assign a control knob or joystick to an action. However, this will significantly reduce the flexibility of such devices, as you will be able to use the knob/joystick only to control one action. By prefixing the movement with a key or button press you can use the same knob/joystick to control multiple actions.
 
 
 ## triggering multiple shortcuts at once

--- a/content/preferences-settings/shortcuts.md
+++ b/content/preferences-settings/shortcuts.md
@@ -144,7 +144,7 @@ element
 effect
 : A shortcut can sometimes have multiple possible _effects_ on a given _element_. For example, a button can be activated as if it was pressed with a plain mouse-click or as if it was pressed with Ctrl+click. A slider's value can be edited, increased/decreased or reset.
 
-So, for example, you can assign the shortcut `e + scroll` to change the value (the _effect_) of the exposure slider (the _element_) of the exposure correction _widget_.
+For example, you can assign the shortcut `e + scroll` to change the value (the _effect_) of the exposure slider (the _element_) of the exposure correction _widget_.
 
 # assigning shortcuts to actions
 

--- a/content/preferences-settings/shortcuts.md
+++ b/content/preferences-settings/shortcuts.md
@@ -174,7 +174,7 @@ You can assign as many shortcuts as you like in a single mapping session and the
 Left-click on a mappable widget to open the shortcut mapping screen for that widget (see below). Left-click anywhere else on the screen to open the shortcut mapping screen, expanded (where possible) based on the part of the screen you have clicked on. This screen can be used to alter the action assigned to a shortcut and to configure shortcuts for non-visual actions. Entering the shortcut mapping screen exits visual shortcut mapping mode.
 
 **To update existing shortcuts:**
-define a second shortcut against the same widget. If you attempt to reallocate an existing shortcut to a new action, you will be notified of the conflict and prompted to replace the existing shortcut.
+Define a second shortcut against the same widget. If you attempt to reallocate an existing shortcut to a new action, you will be notified of the conflict and prompted to replace the existing shortcut.
 
 **To change the default speed of a slider:**
 Scroll with your mouse wheel while in visual mapping mode (without pressing any other buttons/keys) when hovering over the slider -- scroll up to increase and down to decrease. When you leave mapping mode, normal mouse scrolls over that slider will change its value with the adjusted speed.

--- a/content/preferences-settings/shortcuts.md
+++ b/content/preferences-settings/shortcuts.md
@@ -38,7 +38,7 @@ As the two action types are inherently different, so are the shortcuts you can u
 For example:
 
 - The key `e` can be used to focus a module, or to toggle it on/off
-- The key `e`, combined with up/down movements or your pointing device, can be used to control the value of a slider 
+- The key `e`, combined with up/down movements or your pointing device, can be used to control the value of a slider
 
 If you are using keyboard and mouse, **all shortcuts must start with one or more key presses**, as mouse actions in isolation are used to navigate and interact with the UI.
 
@@ -48,12 +48,12 @@ If you have an external controller, you can trigger discrete actions by pressing
 
 The simplest shortcut consists of just one key press (e.g., `E`).
 The same key can be repeated up to three times, so also `E + E` and `E + E + E` are valid, and distinct, shortcuts.
-You can further extend a shortcut with up to three clicks of the same mouse button. So, `E + E + left-click` or `E + right-click + right-click` are also valid shortcuts.
-Finally, if your fingers are very nimble and you really need to go there, you can add either or both of the mouse buttons that you haven't incorporated yet. So, also `E + left-click + middle-click` and `E + E + right-click + right-click + right-click + left-click + middle-click` are valid shortcuts.
+You can further extend a shortcut with up to three clicks of different mouse buttons. So, `E + E + left-click` or `E + right-click + left-click` are also valid shortcuts.
+Finally, if your fingers are very nimble and you really need to go there, you can repeat the last click up to three times. So, also `E + left-click + middle-click + middle-click` and `E + E + middle-click + left-click + right-click + right-click + right-click` are valid shortcuts.
 Hence, the most complex shortcut can consist of 8 key/button presses:
 * Three key presses of the same `key`, followed by
-* Three presses of any mouse button, followed by
-* 1 press of each remaining mouse button.
+* Three presses of the three mouse buttons, followed by
+* 2 more repetions of the last click.
 
 Your shortcut can include one or more modifiers (`Shift`, `Ctrl` and `Alt`). In this case, the modifier(s) have to be held down while executing the remainder of the shortcut. So, `Ctrl + E + E` means holding down `Ctrl` while pressing `E` twice in a rapid sequence.
 
@@ -67,6 +67,9 @@ If you are a MacOs user, your shortcuts will use `Cmd` instead of `Ctrl` and `Op
 If you are defining a continuous shortcut, then the movement part of the shortcut must be executed while the last key, mouse or controller button is held down.
 
 For example, the shortcut `E + E + pan`, can be activated by pressing `E` twice, holding down `E` on the second press and moving the mouse horizontally. While you are holding down `E`, moving the mouse horizontally will adjust the value associated with the shortcut's action. As you release the `E` key, moving the mouse horizontally will just move the mouse on the screen.
+
+**Long keypresses.** 
+The last repetition of a key in a shortcut can be either a _short_ (i.e., normal) or _long_ keypress, defined as holding down the key for a bit longer than the duration of a double click. Hence `E + E` and `E + E(long)` are two distinct shortcuts that can be assigned to different actions. The associated action triggers when the key is released, which entails that a shortcut ending with a long press cannot be used for a continuos shortcut.
 
 **Triggering multiple shortcuts at once.** Note that `E + A` is not a valid shortcut, and darktable will interpret it as a two different shortcuts: `E` followed by `A`. This is by design, as the system allows one to trigger multiple continuous shortcuts at once.
 For example, if both `E + scroll` and `A + scroll` are mapped to a slider (or if you have fallbacks enabled), then scrolling with the mouse while holding down both `E` and `A` will move both sliders. If you have a series of keys assigned to nodes in a curve (e.g, tone equalizer) this allows you to move multiple nodes in parallel.

--- a/content/preferences-settings/shortcuts.md
+++ b/content/preferences-settings/shortcuts.md
@@ -37,8 +37,8 @@ As the two action types are inherently different, so are the shortcuts you can u
 
 For example:
 
-- The key `e` can be used to focus a module, or to toggle it on/off
-- The key `e`, combined with up/down movements or your pointing device, can be used to control the value of a slider
+- The key `E` can be used to focus a module, or to toggle it on/off
+- The key `E`, combined with up/down movements or your pointing device, can be used to control the value of a slider
 
 If you are using keyboard and mouse, **all shortcuts must start with one or more key presses**, as mouse actions in isolation are used to navigate and interact with the UI.
 

--- a/content/preferences-settings/shortcuts.md
+++ b/content/preferences-settings/shortcuts.md
@@ -55,7 +55,14 @@ Hence, the most complex shortcut can consist of 8 key/button presses:
 * Three presses of any mouse button, followed by
 * 1 press of each remaining mouse button.
 
-Your shortcut can include one or more modifiers (`Shift`, `Ctrl/Cmd` and `Alt/Option`). In this case, the modifier(s) have to be held down while executing the remainder of the shortcut. So, `Ctrl + E + E` means holding down `Ctrl` while pressing `E` twice in a rapid sequence.
+Your shortcut can include one or more modifiers (`Shift`, `Ctrl` and `Alt`). In this case, the modifier(s) have to be held down while executing the remainder of the shortcut. So, `Ctrl + E + E` means holding down `Ctrl` while pressing `E` twice in a rapid sequence.
+
+---
+
+**Note:**
+If you are a MacOs user, your shortcuts will use `Cmd` instead of `Ctrl` and `Option` instead of `Alt`
+
+---
 
 If you are defining a continuous shortcut, then the movement part of the shortcut must be executed while the last key, mouse or controller button is held down.
 
@@ -64,11 +71,10 @@ For example, the shortcut `E + E + pan`, can be activated by pressing `E` twice,
 **Triggering multiple shortcuts at once.** Note that `E + A` is not a valid shortcut, and darktable will interpret it as a two different shortcuts: `E` followed by `A`. This is by design, as the system allows one to trigger multiple continuous shortcuts at once.
 For example, if both `E + scroll` and `A + scroll` are mapped to a slider (or if you have fallbacks enabled), then scrolling with the mouse while holding down both `E` and `A` will move both sliders. If you have a series of keys assigned to nodes in a curve (e.g, tone equalizer) this allows you to move multiple nodes in parallel.
 
-
 **Shortcuts must be unique within a view.**
 A single action may have multiple shortcuts but a single shortcut can only be linked to one action in a given darktable view -- you can't chain actions together except by applying a preset or style. You can, however, set up a single shortcut that does one thing in the lighttable view, say, and another in the darkroom view.
 
-**Additional modifiers.** As mentioned above, the only valid modifiers are the Shift, Ctrl/Cmd and Alt/Option keys on the keyboard. You can define additional keys (or device buttons) as modifiers by assigning keys/buttons to the "global/modifier" action. However, these will merely function as extra Ctrl, Alt or Shift keys -- you cannot create "new" modifiers.
+**Additional modifiers.** As mentioned above, the only valid modifiers are the `Shift`, `Ctrl` and `Alt` keys on the keyboard. You can define additional keys (or device buttons) as modifiers by assigning keys/buttons to the "global/modifier" action. However, these will merely function as extra `Ctrl`, `Alt` or `Shift` keys -- you cannot create "new" modifiers.
 
 ## defining continuous shortcuts
 
@@ -190,7 +196,7 @@ For example, the predefined shortcut `Tab` triggers the action `globals/panels/a
 
 Actions in the "views" section can only be executed from the specified darktable view. As with global actions, most do not have specific _elements_ as they are used to perform one-off operations.
 
-For example, the predefined shortcut `Ctrl/Cmd + B` triggers the action `views/darktable/guide lines/toggle`, which toggles guide lines in the darktable view.
+For example, the predefined shortcut `Ctrl + B` triggers the action `views/darktable/guide lines/toggle`, which toggles guide lines in the darktable view.
 
 ## actions on modules
 

--- a/content/preferences-settings/shortcuts.md
+++ b/content/preferences-settings/shortcuts.md
@@ -22,6 +22,23 @@ Darktable comes with many predefined shortcuts using keyboard or keyboard and mo
 
 The recommended way to assign shortcuts to visual elements is the [visual shortcut mapping](#visual-shortcut-mapping) mode.
 
+# in a nutshell
+
+If you just want to assign a specific key to toggle a button, the process is the following:
+
+1. Click on the ![visual mapping button](./shortcuts/visual-mapping-button.png#icon) icon in the [top panel](../overview/user-interface/top-panel.md)
+2. Hover the button that you want to control
+3. Press the key that you want to use to control the button
+
+Similarly, to control a slider with a shortcut you can:
+
+1. Click on the ![visual mapping button](./shortcuts/visual-mapping-button.png#icon) icon
+2. Hover the slider that you want to control
+3. Press the key that you want to use to control the slider, and scroll the mouse wheel or move the mouse horizontally, vertically or diagonally
+
+The system is very flexible and powerful, and this is just scratching the surface.
+Keep on reading to understand it better and learn how to make the most of it.
+
 # types of actions and shortcuts
 
 There are two types of actions:
@@ -29,35 +46,35 @@ There are two types of actions:
 _Discrete_ actions
 : E.g., executing a command, focusing a UI element or resetting a slider
 
-_Continuous actions_
+_Directional actions_
 : E.g., adjusting the value of a slider or scrolling through a list of presets
 
 As the two action types are inherently different, so are the shortcuts you can use to trigger them:
 
 - _Discrete actions_ can be triggered by _discrete shortcuts_ consisting only of key presses and optionally mouse clicks
-- _Continuous actions_ need also a direction (and, in the case of sliders, a magnitude). Hence, the corresponding _continuous shortcuts_ will also incorporate a mouse movement
+- _Directional actions_ need also a direction (and, in the case of sliders, a magnitude). Hence, the corresponding _directional shortcuts_ will also incorporate a mouse movement
 
 For example:
 
 - The key `e` can be used to focus a module, or to toggle it on/off
-- The key `e`, combined with up/down movements or your pointing device, can be used to control the value of a slider
+- The key `e`, combined with up/down movements or the mouse, can be used to control the value of a slider
 
 ---
 
 **Note:**
-By construction, a _continuous shortcut_ is sufficiently expressive to trigger a _discrete action_. The opposite is not true. However, it is possible to use a combination of two _discrete shortcuts_ to control a _continuous action_. For example, you can use two different shortcuts to trigger the `up` and `down` effects of a slider (see [anatomy of an action](#anatomy-of-an-action)).
+By construction, a _directional shortcut_ is sufficiently expressive to trigger a _discrete action_. The opposite is not true. However, it is possible to use a combination of two _discrete shortcuts_ to control a _directional action_. For example, you can use two different shortcuts to trigger the `up` and `down` effects of a slider (see [anatomy of an action](#anatomy-of-an-action)).
 
 ---
 
 If you are using keyboard and mouse, **all shortcuts must start with one or more key presses**, as mouse actions in isolation are used to navigate and interact with the UI.
 
-If you have an input device, you can trigger discrete actions by pressing one or more buttons on the controller. Continuous actions can use a combination of buttons and a knob/joystick movement, or just knob/joystick movement.
+If you have an input device, you can trigger discrete actions by pressing one or more buttons on the controller. Directional actions can use a combination of buttons and a knob/joystick movement, or just knob/joystick movement.
 
 # anatomy of a shortcut
 
 The simplest shortcut consists of just one key press (e.g., `e`).
 
-The same key can be repeated up to three times, so also `e double-press` and `e triple-press` are valid, and distinct, shortcuts.
+The same key can be repeated up to three times, so also `e double-press` (i.e., `e` pressed and released twice in quick succession) and `e triple-press` (i.e., `e` pressed and released three times in quick succession) are valid, and distinct, shortcuts.
 
 You can further extend a shortcut with up to three clicks of different mouse buttons. So, `e double-press + left click` or `e + right click + left click` are also valid shortcuts.
 
@@ -68,7 +85,7 @@ Hence, the most complex shortcut can consist of 8 key/button presses:
 * Three presses of the three mouse buttons, followed by
 * 2 more repetitions of the last click.
 
-Your shortcut can include one or more modifiers (`shift`, `ctrl` and `alt`). In this case, for a continuous shortcut, both the last key and the modifier must be pressed down when you execute the movement. For example, `ctrl + e double-press + pan` means that while moving the mouse left and/or right both  `e` and `ctrl` must be pressed down.
+Your shortcut can include one or more modifiers (`shift`, `ctrl` and `alt`). In this case, for a directional shortcut, both the last key and the modifier must be pressed down when you execute the movement. For example, `ctrl + e double-press + pan` means that while moving the mouse left and/or right both  `e` and `ctrl` must be pressed down.
 
 ---
 
@@ -77,17 +94,19 @@ If you are a MacOs user, your shortcuts will use `cmd` instead of `ctrl` and `op
 
 ---
 
-If you are defining a continuous shortcut, then the movement part of the shortcut must be executed while the last key, mouse or controller button is held down.
+If you are defining a directional shortcut, then the movement part of the shortcut must be executed while the last key, mouse or controller button is held down.
 
 For example, the shortcut `e double-press + pan`, can be activated by pressing `e` twice, holding down `e` on the second press and moving the mouse horizontally while the key is pressed.
 
-## short and long key presses
+## short and long presses
 
-By default, all key presses in a shortcut are _short_, i.e., the key is pressed and immediately released. However, the last repetition of a key in a shortcut can also be a _long_ key press, defined as holding down the key for a bit longer than the duration of a double click. Hence `e double-press` and `e long double-press` are two distinct shortcuts that can be assigned to different actions. The associated action triggers when the key is released, which entails that a shortcut ending with a long press cannot be used for a continuos shortcut.
+By default, all key presses and button clicks in a shortcut are _short_, i.e., the key/button is pressed and immediately released. However, the last repetition of a key/button press in a shortcut can also be a _long_ one.
+You can turn a normal key/button press into a long press by simply holding it a little longer before releasing it (longer than double-click speed but shorter than twice double-click speed). This applies to key presses and mouse clicks alike.
+Hence `e double-press` and `e long double-press` are two distinct shortcuts that can be assigned to different actions. The associated action triggers when the key is released, which entails that a shortcut ending with a long press cannot be used for a directional shortcut.
 
-## movements in continuous shortcuts
+## movements in directional shortcuts
 
-The following movements are supported when defining continuous shortcuts:
+The following movements are supported when defining directional shortcuts:
 
 -   Movement of the mouse scroll wheel
 -   Horizontal, vertical or diagonal movement of the mouse cursor
@@ -152,7 +171,7 @@ The mouse cursor will change as you hover over UI widgets, to indicate whether o
 -   ![Don't signal](./shortcuts/no-signal.png#icon) indicates that there is no mappable widget under the cursor.
 
 **To define new shortcuts:**
-press a key combination while hovering over a mappable widget. A _default action_ will be assigned to that shortcut based on the type of widget and whether your shortcut includes a movement. See the [common actions](#common-actions) section for examples of some of the defaults.
+press a key combination while hovering over a mappable widget. A _default action_ will be assigned to that shortcut based on the type of widget and whether it is directional. See the [common actions](#common-actions) section for examples of some of the defaults.
 You can assign as many shortcuts as you like in a single mapping session and then exit mapping mode when you are finished by clicking the ![visual mapping button](./shortcuts/visual-mapping-button.png#icon) icon again or right-clicking anywhere on the screen.
 
 **To explore already defined shortcuts:**
@@ -220,7 +239,7 @@ For example, the predefined shortcut `tab` triggers the action `globals/panels/a
 
 Actions in the "views" section can only be executed from the specified darktable view. As with global actions, most do not have specific _elements_ as they are used to perform one-off operations.
 
-For example, the predefined shortcut `ctrl + b` triggers the action `views/darktable/guide lines/toggle`, which toggles guide lines in the darktable view.
+For example, the predefined shortcut `ctrl + b` triggers the action `views/darkroom/guide lines/toggle`, which toggles guide lines in the darktable view. It has an `effect` setting which allows you to directly simulate a right-click on the button, which in this case opens the guide lines configuration popup.
 
 ## actions on modules
 
@@ -248,7 +267,7 @@ _focus_
 : Acts as a _toggle_ that focuses or de-focuses the module. This is useful for modules such as [_crop_](../module-reference/processing-modules/crop.md) or [_tone equalizer_](../module-reference/processing-modules/tone-equalizer.md), whose on-screen controls are only activated when those modules have focus. For _crop_, changes are saved only when the module loses focus.
 
 _instance_
-: Allows you to select actions from the [multiple-instance](../darkroom/processing-modules/multiple-instances.md) menu (e.g. move up/down, create new instance). The discrete action associated to the _instance_ element displays a list of the available options for selection; a continuous action is also available and will move the _preferred module instance_ (see below) up and down the pixelpipe.
+: Allows you to select actions from the [multiple-instance](../darkroom/processing-modules/multiple-instances.md) menu (e.g. move up/down, create new instance). The discrete action associated to the _instance_ element displays a list of the available options for selection; a directional action is also available and will move the _preferred module instance_ (see below) up and down the pixelpipe.
 
 If an action affects a processing module that can have multiple instances, you can choose which instance to adjust with a given shortcut. By default, all actions will affect the "preferred" instance, as defined using the settings in [preferences > miscellaneous > shortcuts with multiple instances](./miscellaneous.md#shortcuts-with-multiple-instances).
 
@@ -273,7 +292,7 @@ For example, the predefined shortcut `shift + O` is associated to `views/darkroo
 A dropdown is a multi-selection box and has the following elements available:
 
 _selection_
-: Allows values to be selected from the dropdown list in various ways. The default action, when assigning a discrete shortcut to a dropdown, is to display a popup _edit_ box with a list of the available values for selection; A continuous shortcut (i.e., including a mouse movement) will scroll through the available values.
+: Allows values to be selected from the dropdown list in various ways. The default action, when assigning a discrete shortcut to a dropdown, is to display a popup _edit_ box with a list of the available values for selection; A directional shortcut (i.e., including a mouse movement) will scroll through the available values.
 
 _button_
 : A standard _button_ element that allows the button to the right of the dropdown (if present) to be activated. For example, the _aspect_ dropdown in the [_crop_](../module-reference/processing-modules/crop.md) module has a button that allows the crop controls to be changed from portrait to landscape and vice versa.
@@ -283,7 +302,7 @@ _button_
 A slider allows you to continuously alter an integer or decimal value, and has the following elements available:
 
 _value_
-: Allows the current value of the slider to be altered. The default action, when assigning a discrete shortcut to a slider, is to display a popup _edit_ box so you can enter a value; A continuous shortcut will change the value up and down. Value elements are also used for modifying some on-screen graphs. When modifying the _value_ element with a shortcut you may not exceed the bounds set in the visual slider.
+: Allows the current value of the slider to be altered. The default action, when assigning a discrete shortcut to a slider, is to display a popup _edit_ box so you can enter a value; A directional shortcut will change the value up and down. Value elements are also used for modifying some on-screen graphs. When modifying the _value_ element with a shortcut you may not exceed the bounds set in the visual slider.
 
 _force_
 : This is the same as the _value_ element described above, but it allows you to exceed the bounds set in the visual slider.

--- a/content/preferences-settings/shortcuts.md
+++ b/content/preferences-settings/shortcuts.md
@@ -77,7 +77,7 @@ If you are a MacOs user, your shortcuts will use `Cmd` instead of `Ctrl` and `Op
 
 If you are defining a continuous shortcut, then the movement part of the shortcut must be executed while the last key, mouse or controller button is held down.
 
-For example, the shortcut `E + E + pan`, can be activated by pressing `E` twice, holding down `E` on the second press and moving the mouse horizontally and moving the mouse horizontally will the key is pressed.
+For example, the shortcut `E + E + pan`, can be activated by pressing `E` twice, holding down `E` on the second press and moving the mouse horizontally while the key is pressed.
 
 **Short and long key presses.** 
 By default, all key presses in a shortcut are _short_, i.e., the key is pressed and immediately released. However, the last repetition of a key in a shortcut can also be a _long_ keypress, defined as holding down the key for a bit longer than the duration of a double click. Hence `E + E` and `E + E(long)` are two distinct shortcuts that can be assigned to different actions. The associated action triggers when the key is released, which entails that a shortcut ending with a long press cannot be used for a continuos shortcut.

--- a/content/preferences-settings/shortcuts.md
+++ b/content/preferences-settings/shortcuts.md
@@ -167,7 +167,7 @@ The mouse cursor will change as you hover over UI widgets, to indicate whether o
 -   ![Don't signal](./shortcuts/no-signal.png#icon) indicates that there is no mappable widget under the cursor.
 
 **To define new shortcuts:**
-press a key combination while hovering over a mappable widget. A _default action_ will be assigned to that shortcut based on the type of widget and whether it is directional. See the [common actions](#common-actions) section for examples of some of the defaults.
+Press a key combination while hovering over a mappable widget. A _default action_ will be assigned to that shortcut based on the type of widget and whether it is directional. See the [common actions](#common-actions) section for examples of some of the defaults.
 You can assign as many shortcuts as you like in a single mapping session and then exit mapping mode when you are finished by clicking the ![visual mapping button](./shortcuts/visual-mapping-button.png#icon) icon again or right-clicking anywhere on the screen.
 
 **To explore already defined shortcuts:**

--- a/content/preferences-settings/shortcuts.md
+++ b/content/preferences-settings/shortcuts.md
@@ -225,7 +225,7 @@ The following is a list of some of the actions to which you can assign shortcuts
 ---
 
 **Note:**
-some actions may have no effect. For example, all sliders include a _button_ element, regardless of whether such a button is actually present alongside a given slider.
+Some actions may have no effect. For example, all sliders include a _button_ element, regardless of whether such a button is actually present alongside a given slider.
 
 ---
 

--- a/content/preferences-settings/shortcuts.md
+++ b/content/preferences-settings/shortcuts.md
@@ -46,16 +46,24 @@ If you have an external controller, you can trigger discrete actions by pressing
 
 # anatomy of a shortcut
 
-Shortcuts can consist of up to three key/button presses **of the same key/button** (in a quick sequence).
-So, for example, `E`, `E + E` and `E + E + E` are all valid shortcuts to trigger discrete actions, as well as `E + left-click`, `E + right-click` or `E + E + left-click`.
-
-On the contrary, `E + A` is not a valid shortcut, and darktable will interpret it as a two different shortcuts: `E` followed by `A`.
+The simplest shortcut consists of just one key press (e.g., `E`).
+The same key can be repeated up to three times, so also `E + E` and `E + E + E` are valid, and distinct, shortcuts.
+You can further extend a shortcut with up to three clicks of the same mouse button. So, `E + E + left-click` or `E + right-click + right-click` are also valid shortcuts.
+Finally, if your fingers are very nimble and you really need to go there, you can add either or both of the mouse buttons that you haven't incorporated yet. So, also `E + left-click + middle-click` and `E + E + right-click + right-click + right-click + left-click + middle-click` are valid shortcuts.
+Hence, the most complex shortcut can consist of 8 key/button presses:
+* Three key presses of the same `key`, followed by
+* Three presses of any mouse button, followed by
+* 1 press of each remaining mouse button.
 
 Your shortcut can include one or more modifiers (`Shift`, `Ctrl/Cmd` and `Alt/Option`). In this case, the modifier(s) have to be held down while executing the remainder of the shortcut. So, `Ctrl + E + E` means holding down `Ctrl` while pressing `E` twice in a rapid sequence.
 
 If you are defining a continuous shortcut, then the movement part of the shortcut must be executed while the last key, mouse or controller button is held down.
 
 For example, the shortcut `E + E + pan`, can be activated by pressing `E` twice, holding down `E` on the second press and moving the mouse horizontally. While you are holding down `E`, moving the mouse horizontally will adjust the value associated with the shortcut's action. As you release the `E` key, moving the mouse horizontally will just move the mouse on the screen.
+
+**Triggering multiple shortcuts at once.** Note that `E + A` is not a valid shortcut, and darktable will interpret it as a two different shortcuts: `E` followed by `A`. This is by design, as the system allows one to trigger multiple continuous shortcuts at once.
+For example, if both `E + scroll` and `A + scroll` are mapped to a slider (or if you have fallbacks enabled), then scrolling with the mouse while holding down both `E` and `A` will move both sliders. If you have a series of keys assigned to nodes in a curve (e.g, tone equalizer) this allows you to move multiple nodes in parallel.
+
 
 **Shortcuts must be unique within a view.**
 A single action may have multiple shortcuts but a single shortcut can only be linked to one action in a given darktable view -- you can't chain actions together except by applying a preset or style. You can, however, set up a single shortcut that does one thing in the lighttable view, say, and another in the darkroom view.


### PR DESCRIPTION
The documentation about shortcuts was confusing to me. After a few exchanges on pixls.us, I think that I understand things better. Armed with this better understanding, I thought that I was in a good position to try to improve it.

The content is by and large the same, I have just moved things around a bit to keep the information flow more consistent and to add a bit of structure.

In terms of content changes, the only notable one is that I replaced the distinction between **simple** vs. **extended** shortcuts, which seemed a bit arbitrary and that I found confusing. Instead, I used **discrete** vs. **continuous**, as these shortcuts are associated with **discrete** (e.g., click) vs. **continuos** (e.g., change value) UI actions. This also shifts the focus from the type of shortcut that one is defining to the kind of action that one wants to trigger, which IMHO is more logical and hence more understandable and memorable.

I also added a few more concrete examples, which were lacking, and whenever possible aded captions to the paragraph to make it easier to find what one is looking for.

**Edit**: Following some review iterations, the remapped terminology is now **simple --> discrete** and **extended --> directional**.
