### PR TITLE
Clarify order of auto-applied presets

### DIFF
--- a/content/darkroom/processing-modules/presets.md
+++ b/content/darkroom/processing-modules/presets.md
@@ -58,6 +58,8 @@ auto apply this preset to matching images _(processing modules only)_
 
 : _The [image information](../../module-reference/utility-modules/shared/image-information.md) module displays the camera model and lens name for each image. Use this to ensure you have the correct spelling._
 
+: If there is more than one preset with matching parameters for a given image, darktable creates multiple instances of the module, one for each matching preset, in the order they were defined. I.e., the last preset that was created will be placed after all other instances of the module in the pipeline.
+
 only show this preset for matching images _(processing modules only)_
 : Check this box to automatically show the preset in the preset menu, using the same set of filters.
 


### PR DESCRIPTION
This is for https://github.com/darktable-org/darktable/pull/19726.

Clarify the precedence of auto-applied presets.

When reading the pull request in darktable, it seems to imply that _only_ the last preset is applied per module, but in my testing (both with yesterday's nightly and on 5.2) it actually creates one instance per matching preset, so I have worded it accordingly.