### PR TITLE
Remove mention of filmic from tone equalizer's description

### DIFF
--- a/content/module-reference/processing-modules/tone-equalizer.md
+++ b/content/module-reference/processing-modules/tone-equalizer.md
@@ -11,7 +11,7 @@ masking: true
 
 Dodge and burn while preserving local contrast.
 
-The Tone Equalizer module replaces the need for other tone-mapping modules such as the [_shadows and highlights_](./shadows-and-highlights.md), [_tone curve_](./tone-curve.md), [_zone system (deprecated)_](./zone-system.md), and similar modules. It works in linear RGB space and utilizes a user-defined mask to guide the dodging and burning adjustments, helping to preserve local contrast within the image.
+The _tone equalizer_ module replaces the need for other tone-mapping modules such as the [_shadows and highlights_](./shadows-and-highlights.md), [_tone curve_](./tone-curve.md), [_zone system (deprecated)_](./zone-system.md), and similar modules. It works in linear RGB space and utilizes a user-defined mask to guide the dodging and burning adjustments, helping to preserve local contrast within the image.
 
 The following diagram describes how the tone equalizer works:
 


### PR DESCRIPTION
Mentioning filmic is now weird since we have a plethora of tone mappers at hand. Tried to simplify a bit.
