### PR TITLE
Can use shift modifier to select feathering node in masks

### DIFF
--- a/content/darkroom/masking-and-blending/masks/drawn.md
+++ b/content/darkroom/masking-and-blending/masks/drawn.md
@@ -65,7 +65,7 @@ circle
 : Click on the image canvas to place the circle. Scroll while hovering over the circle to change its diameter. Scroll while hovering over the circle's border to change the width of the feathering (the same effect as holding Shift while scrolling with the mouse wheel within the main shape).
 
 ellipse
-: The general principle is the same as for the circle shape. In addition, four nodes are shown on the ellipse line. Click and drag the nodes to adjust the ellipse's eccentricity. Ctrl+click and drag the nodes or use Shift+Ctrl+scroll (with the mouse wheel) to rotate the ellipse. Shift+click within the shape to toggle the gradual decay between equidistant and proportional mode.
+: The general principle is the same as for the circle shape. In addition, four nodes are shown on the ellipse line. Click and drag the nodes to adjust the ellipse's eccentricity. Ctrl+click and drag the nodes or use Shift+Ctrl+scroll (with the mouse wheel) to rotate the ellipse. Alt+click within the shape to toggle the gradual decay between equidistant and proportional mode.
 
 path
 : Click on the image canvas to place three or more nodes and generate a free-format enclosed shape. Terminate the path by right-clicking after having set the last point. By default, nodes are connected with smooth lines. If you want a node to instead define a sharp corner, you can do so by creating it with Ctrl+click.


### PR DESCRIPTION
This relates to this darktable PR: https://github.com/darktable-org/darktable/pull/18896

User can now use Shift when selecting a feather outline node to avoid selecting an adjacent mask node.

The same PR altered the modifier for changing an ellipse mask's feather mode (from Shift to Alt), so update that in doc as well. (Note that the help text at the top of screen when an ellipse mask is selected has not been updated - I've opened a PR about that: https://github.com/darktable-org/darktable/pull/20155).