### PR TITLE
add note on missing deprecated modules group

### DIFF
--- a/content/darkroom/organization/module-groups.md
+++ b/content/darkroom/organization/module-groups.md
@@ -75,3 +75,5 @@ This preset does not include any module groupings. Modules may only be accessed 
 
 This preset contains a list of deprecated modules. This is the only way to access deprecated modules for new edits but be warned: these modules will be removed for new edits in the next release of darktable. This group cannot be duplicated and the modules within it cannot be added to user-created groups.
 
+**Note** Deprecated modules are assigned to this group only temporarily to support a smooth transition to their replacements. After the deprecation period (usually one year), these modules can no longer be used for new edits and are removed from this group. If the group then becomes empty, it will no longer be shown in the presets list.
+


### PR DESCRIPTION
Thank you for taking the time to help the darktable documentation!

# Please include a link to the Pull Request that you are documenting
[#18769](https://github.com/darktable-org/darktable/pull/18769)

# Tell us a little bit about this pull request
Adding a note in content/darkroom/organization/module-groups.md that the deprecated module group may not be visible if no modules have been deprecated recently.