### PR TITLE
Fix 2nd link to "darktable's color dimensions"

### DIFF
--- a/content/module-reference/processing-modules/agx.md
+++ b/content/module-reference/processing-modules/agx.md
@@ -148,7 +148,7 @@ brightness
 : Applies a power function (gamma adjustment) to the image. The black and white points are not affected. Values above 1 will raise the mid-tones, opening up shadows, whereas those below 1 will darken the mid-tones and compress shadows.
 
 saturation
-: Controls color intensity by adjusting the image's chroma. For a precise definition of chroma vs. saturation, please see [_darktable's color dimensions_](./color-dimensions.md). A value of zero makes the image monochrome.
+: Controls color intensity by adjusting the image's chroma. For a precise definition of chroma vs. saturation, please see [_darktable's color dimensions_](../../special-topics/color-management/color-dimensions.md). A value of zero makes the image monochrome.
 
 preserve hue
 : The tone mapping curve, being a per-channel curve, introduces color shifts, with color tending towards the primary (red, green and blue) and secondary (yellow, cyan and magenta) colors in the highlights. At a value of 0%, these color shifts are retained. By raising this slider, the input hues (those before the tone curve) can be partially or fully restored.


### PR DESCRIPTION
Fixed broken link to the page _darktable's color dimensions_