### PR TITLE
Add import extras description to shortcuts doc

### DIFF
--- a/content/preferences-settings/shortcuts.md
+++ b/content/preferences-settings/shortcuts.md
@@ -201,6 +201,9 @@ The following additional options are provided in the shortcut mapping screen:
 export...
 : Export the current shortcut mappings for one or all of your devices (keyboard/mouse, midi, game controller) to an external file. The dialog will show you how many shortcuts exist for each device.
 
+import extras
+: Import extended shortcuts from a system file (`shortcutsrc`, with an optional language suffix, from your darktable installation - not the local config file of the same name). Existing shortcuts matching any in the system file will be replaced. These shortcuts will be localized to your system language if a localized version of the system file is available (currently, only German (`shortcutsrc.de`) in addition to the default English).
+
 import...
 : Import shortcut mappings from an external file for one or all of your devices. When loading a device, you can chose to assign it a different number. This can for example be used to exchange midi layouts. Before loading, you can chose to wipe the specific device first. When loading all from an empty file, this will effectively delete all your shortcuts.
 


### PR DESCRIPTION
Relates to darktable PR: https://github.com/darktable-org/darktable/pull/19500

Add a description of the `import extras` button in the shortcuts preferences page.

This doc change is adapted from another dtdocs PR, which was closed because it  added other, unwanted, details:  https://github.com/darktable-org/dtdocs/pull/783

Note that github reports an additional change on the last line of the file, but that is due to my changed file having a final line-feed at the end. I think is normal enough for the final line to be terminated by a line-feed (other dtdocs files generally end with a line-feed), and I have not tried to fix that.
