### PR TITLE
Update crop doc with aspect ratio display

### DIFF
--- a/content/module-reference/processing-modules/crop.md
+++ b/content/module-reference/processing-modules/crop.md
@@ -12,7 +12,7 @@ Whenever this module is in focus, the full uncropped image will be shown, overla
 
 ![screen controls](./crop/screen-controls.png#w75)
 
-Resize the crop by dragging the border and corner handles.
+Resize the crop by dragging the border and corner handles. During resizing, the dimensions (in pixels) and aspect ratio of the crop area are shown in the center of the crop area.
 
 Move the crop rectangle by clicking and dragging inside the crop area. Constrain movement to the horizontal/vertical axis by holding Ctrl/Shift, respectively while dragging. Commit changes by giving focus to another module.
 


### PR DESCRIPTION
Relates to this darktable PR: https://github.com/darktable-org/darktable/pull/20191

The darktable change displays the crop area aspect ratio during the crop area resizing. 

I don't think we currently mention in the doc that the pixel size is already shown, so I've added a sentence mentioning both. It might be that we decide mot to bother mentioning what is displayed in the centre, since it is probably obvious, in which case we can just close this doc PR.