### PR TITLE
Can switch picker mode with ctrl+click

### DIFF
--- a/content/darkroom/processing-modules/module-controls.md
+++ b/content/darkroom/processing-modules/module-controls.md
@@ -60,6 +60,8 @@ Activate area mode by either right-clicking or Ctrl+clicking the picker icon and
 
 In modules where only one mode is available, left-clicking the icon will usually toggle that mode on and off.
 
+In modules where both modes are available, Ctrl+clicking anywhere on the image will switch modes.
+
 # keyboard shortcuts
 
 Module parameters can also be adjusted using keyboard shortcuts. See [preferences > shortcuts](../../preferences-settings/shortcuts.md) for more information.


### PR DESCRIPTION
Relates to this darktable PR: https://github.com/darktable-org/darktable/pull/19827

It is now possible to switch the picker mode (point or area) by a Ctrl+click on the image.