### PR TITLE
Add vectorize button to external raster masks doc

### DIFF
--- a/content/module-reference/processing-modules/external-raster.md
+++ b/content/module-reference/processing-modules/external-raster.md
@@ -21,7 +21,10 @@ Using this module, external raster mask files are made available as a raster mas
 # module controls
 
 file selection
-: Choose the external raster file to use. File selection is inactive if the rasterfile root folder has not been defined in [preferences > processing](../../preferences-settings/processing.md).
+: Choose the external raster file to use. File selection is inactive if the raster mask files root folder has not been defined in [preferences > processing](../../preferences-settings/processing.md).
 
 mode
 : Choose any of the RGB channels, or a combination of them, to generate the raster mask from.
+
+vectorize
+: Create a separate path mask for each shape identified in the current raster mask, and add all the resulting path masks to the mask manager.

--- a/content/module-reference/processing-modules/external-raster.md
+++ b/content/module-reference/processing-modules/external-raster.md
@@ -21,7 +21,7 @@ Using this module, external raster mask files are made available as a raster mas
 # module controls
 
 file selection
-: Choose the external raster file to use. File selection is inactive if the raster mask files root folder has not been defined in [preferences > processing](../../preferences-settings/processing.md).
+: Choose the external raster file to use. The initial raster mask files root folder can be set in [preferences > processing](../../preferences-settings/processing.md).
 
 mode
 : Choose any of the RGB channels, or a combination of them, to generate the raster mask from.


### PR DESCRIPTION
Relates to this darktable PR: https://github.com/darktable-org/darktable/pull/20198

Add the new _vectorize_ button to the _external raster masks_ module documentation. This allows users to generate path masks from raster mask files.

For experimenting, I used the PFM file linked to in [one of the PR comments](https://github.com/darktable-org/darktable/pull/20198#issuecomment-3792846239).

I also noticed that the text for a preference related to external raster masks was incorrect, so I updated it to match the current preferences text.