### PR TITLE
add info about new preview combobox

### DIFF
--- a/content/module-reference/utility-modules/lighttable/styles.md
+++ b/content/module-reference/utility-modules/lighttable/styles.md
@@ -21,11 +21,11 @@ A large selection of "camera" styles is provided with darktable. These styles ar
 
 # module controls
 
+hide preview
+: Use this checkbox to hide the preview on the tooltip entirely. This can be useful on slower computers, where rendering the preview may take additional time.
+
 create duplicate
 : When applying a style to images, tick this box to create a duplicate of each image before applying the chosen style to that duplicate. Disable this option to apply the chosen style directly to the selected images. Beware that in this case any existing history stack is overwritten (depending on the mode -- see below) and cannot be recovered.
-
-preview
-: Use this combobox to change the preview size ("Default" or "Large") or to hide the preview entirely. Hiding the preview can improve performance on slower computers, where rendering may take additional time.
 
 mode
 : As with the [history stack](./history-stack.md) module, this combobox allows you to either "append" the style to the current history stack or to "overwrite" the history stack of the target image.
@@ -50,3 +50,9 @@ import
 
 export
 : Save the selected style to disk as a `.dtstyle` file. This allows styles to be published and shared with other users.
+
+# preferences
+The "preferences..." option in the presets menu allows you to adjust the following settings:
+
+preview size
+: Set the size of the preview on the tooltip. The available options are: default and large.

--- a/content/module-reference/utility-modules/lighttable/styles.md
+++ b/content/module-reference/utility-modules/lighttable/styles.md
@@ -24,6 +24,9 @@ A large selection of "camera" styles is provided with darktable. These styles ar
 create duplicate
 : When applying a style to images, tick this box to create a duplicate of each image before applying the chosen style to that duplicate. Disable this option to apply the chosen style directly to the selected images. Beware that in this case any existing history stack is overwritten (depending on the mode -- see below) and cannot be recovered.
 
+preview
+: Use this combobox to change the preview size ("Default" or "Large") or to hide the preview entirely. Hiding the preview can improve performance on slower computers, where rendering may take additional time.
+
 mode
 : As with the [history stack](./history-stack.md) module, this combobox allows you to either "append" the style to the current history stack or to "overwrite" the history stack of the target image.
 


### PR DESCRIPTION
This is a proposal for the documentation of a new option in the styles module introduced with PR [#20255](https://github.com/darktable-org/darktable/pull/20255).
The PR introduces a new combo box in the styles module for the preview on the tool tip. There are three options: default, large, no. With "no" it is possible to hide the preview.

