### PR TITLE
Watermark: add note about effect of framing on position

### DIFF
--- a/content/module-reference/processing-modules/watermark.md
+++ b/content/module-reference/processing-modules/watermark.md
@@ -72,6 +72,6 @@ y offset
 
 ---
 
-**Note**: When using the watermark in combination with the framing module, the added frame affects the watermark’s position. For example, if you align the watermark to an edge, it may appear within the frame instead of on the actual image. To ensure the watermark is positioned relative to the image itself, you can manually manually [adjust the module order](../../../darkroom/pixelpipe/the-pixelpipe-and-module-order.md#changing-module-order) so that the framing module comes after the watermark module in the pixelpipe.
+**Note**: When using the watermark in combination with the framing module, the added frame affects the watermark’s position. For example, if you align the watermark to an edge, it may appear within the frame instead of on the actual image. To ensure the watermark is positioned relative to the image itself, you can manually manually [adjust the module order](../../darkroom/pixelpipe/the-pixelpipe-and-module-order.md#changing-module-order) so that the framing module comes after the watermark module in the pixelpipe.
 
 ---

--- a/content/module-reference/processing-modules/watermark.md
+++ b/content/module-reference/processing-modules/watermark.md
@@ -69,3 +69,9 @@ x offset
 
 y offset
 : Pixel-independent offset relative to the choice of alignment on the y-axis.
+
+---
+
+**Note**: When using the watermark in combination with the framing module, keep in mind that the added frame affects the watermark’s position. For example, if you align the watermark to an edge, it may appear within the frame instead of on the actual image. To ensure the watermark is positioned relative to the image itself, you can manually adjust the module order so that the framing module comes after the watermark module in the pixelpipe.
+
+---

--- a/content/module-reference/processing-modules/watermark.md
+++ b/content/module-reference/processing-modules/watermark.md
@@ -72,6 +72,6 @@ y offset
 
 ---
 
-**Note**: When using the watermark in combination with the framing module, keep in mind that the added frame affects the watermark’s position. For example, if you align the watermark to an edge, it may appear within the frame instead of on the actual image. To ensure the watermark is positioned relative to the image itself, you can manually adjust the module order so that the framing module comes after the watermark module in the pixelpipe.
+**Note**: When using the watermark in combination with the framing module, the added frame affects the watermark’s position. For example, if you align the watermark to an edge, it may appear within the frame instead of on the actual image. To ensure the watermark is positioned relative to the image itself, you can manually manually [adjust the module order](../../../darkroom/pixelpipe/the-pixelpipe-and-module-order.md#changing-module-order) so that the framing module comes after the watermark module in the pixelpipe.
 
 ---


### PR DESCRIPTION
This is a proposal for issue #724.

I added a note to the documentation of the watermark module that the framing module affects the positioning of the watermark and that this can be solved by changing the default order of the modules manually.

closes #724 
