### PR TITLE
Add documentation for Shift+Mouse wheel for gradient masks

### DIFF
--- a/content/darkroom/masking-and-blending/masks/drawn.md
+++ b/content/darkroom/masking-and-blending/masks/drawn.md
@@ -97,7 +97,7 @@ brush
 gradient
 : The gradient shape is a linear gradient which extends from a given point to the edge of the image.
 
-: Click on the image canvas to define the position of the line that defines 50% opacity. Dotted lines indicate the distance beyond which the opacity is 100% and 0%. Between these dotted lines the opacity changes linearly. You can change the distance between the dotted lines by scrolling with your mouse wheel and pressing Shift.
+: Click the image canvas to place the gradient. The central line marks 50% opacity, the dotted lines to the sides indicate 100% and 0% opacity respectively. Between these dotted lines the opacity changes linearly. You can compress/expand the distance between the dotted lines by scrolling with your mouse wheel while pressing Shift. Note that the dotted lines will only appear while hovering over one of the lines with your cursor.
 
 : The line has two anchor nodes which you can drag to change the rotation of the gradient. You can also set the rotation angle when placing the gradient shape by clicking and dragging to place the shape.
 

--- a/content/darkroom/masking-and-blending/masks/drawn.md
+++ b/content/darkroom/masking-and-blending/masks/drawn.md
@@ -97,7 +97,7 @@ brush
 gradient
 : The gradient shape is a linear gradient which extends from a given point to the edge of the image.
 
-: Click on the image canvas to define the position of the line that defines 50% opacity. Dotted lines indicate the distance beyond which the opacity is 100% and 0%. Between these dotted lines the opacity changes linearly. 
+: Click on the image canvas to define the position of the line that defines 50% opacity. Dotted lines indicate the distance beyond which the opacity is 100% and 0%. Between these dotted lines the opacity changes linearly. You can change the distance between the dotted lines by scrolling with your mouse wheel and pressing Shift.
 
 : The line has two anchor nodes which you can drag to change the rotation of the gradient. You can also set the rotation angle when placing the gradient shape by clicking and dragging to place the shape.
 


### PR DESCRIPTION
The distance between the dotted lines in gradient masks can be changed with mouse-wheel+shift. 
This information was missing in the documentation, and a stumbled upon it by accident.