### PR TITLE
Try to enable PDF and ePub creation

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: nix develop --command bash -c "cd tools && bash generate-translations.sh --no-update"
 
       - name: Build epub
-        run: nix-shell --run './tools/build-epub.sh'
+        run: nix develop --command bash -c "cd toold && bash build-epub.sh"
 
       - name: Clear
         run: nix develop --command bash -c "rm -rf public"
@@ -35,4 +35,4 @@ jobs:
         run: nix develop --command bash -c "hugo"
 
       - name: Build PDF
-        run: nix-shell --run 'hugo server --disableFastRender -verbose --config config-pdf.yaml & sleep 30 && weasyprint -v http://localhost:1313/dtdocs/index.html ./public/darktable_user_manual.pdf && pkill hugo'
+        run: nix develop --command bash -c "hugo server --disableFastRender -verbose --config config-pdf.yaml & sleep 30 && weasyprint -v http://localhost:1313/dtdocs/index.html ./public/darktable_user_manual.pdf && pkill hugo"

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -35,4 +35,4 @@ jobs:
         run: nix develop --command bash -c "hugo"
 
       - name: Build PDF
-        run: nix develop --command bash -c "hugo server --disableFastRender -verbose --config config-pdf.yaml & sleep 30 && weasyprint -v http://localhost:1313/dtdocs/index.html ./public/darktable_user_manual.pdf && pkill hugo"
+        run: nix develop --command bash -c "hugo server --disableFastRender --config config-pdf.yaml & sleep 30 && weasyprint -v http://localhost:1313/dtdocs/index.html ./public/darktable_user_manual.pdf && pkill hugo"

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -25,8 +25,14 @@ jobs:
       - name: Generate translated files
         run: nix develop --command bash -c "cd tools && bash generate-translations.sh --no-update"
 
+      - name: Build epub
+        run: nix-shell --run './tools/build-epub.sh'
+
       - name: Clear
         run: nix develop --command bash -c "rm -rf public"
 
       - name: Build
         run: nix develop --command bash -c "hugo"
+
+      - name: Build PDF
+        run: nix-shell --run 'hugo server --disableFastRender -verbose --config config-pdf.yaml & sleep 30 && weasyprint -v http://localhost:1313/dtdocs/index.html ./public/darktable_user_manual.pdf && pkill hugo'

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -25,17 +25,17 @@ jobs:
       - name: Generate translated files
         run: nix develop --command bash -c "cd tools && bash generate-translations.sh --no-update"
 
-      - name: Build epub
-        run: nix develop --command bash -c "cd tools && bash build-epub.sh"
-
       - name: Clear
         run: nix develop --command bash -c "rm -rf public"
 
       - name: Build
         run: nix develop --command bash -c "hugo"
 
+      - name: Build epub
+        run: nix develop --command bash -c "cd tools && bash build-epub.sh"
+
       - name: Build PDF
-        run: nix develop --command bash -c "hugo server --disableFastRender --config config-pdf.yaml & sleep 30 && weasyprint -v http://localhost:1313/dtdocs/index.html ./public/darktable_user_manual.pdf && pkill hugo"
+        run: nix develop --command bash -c "hugo server --disableFastRender --config config-pdf.yaml & sleep 30 && weasyprint -v http://localhost:1313/dtdocs/en/index.html ./public/darktable_user_manual.pdf && pkill hugo"
 
       - name: Archive production artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: nix develop --command bash -c "cd tools && bash generate-translations.sh --no-update"
 
       - name: Build epub
-        run: nix develop --command bash -c "cd toold && bash build-epub.sh"
+        run: nix develop --command bash -c "cd tools && bash build-epub.sh"
 
       - name: Clear
         run: nix develop --command bash -c "rm -rf public"

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -36,3 +36,12 @@ jobs:
 
       - name: Build PDF
         run: nix develop --command bash -c "hugo server --disableFastRender --config config-pdf.yaml & sleep 30 && weasyprint -v http://localhost:1313/dtdocs/index.html ./public/darktable_user_manual.pdf && pkill hugo"
+
+      - name: Archive production artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: public-without-markdown
+          path: |
+            public
+            !public/**/*.md
+            !public/**/*.html

--- a/themes/hugo-darktable-docs-epub-theme/layouts/partials/css.html
+++ b/themes/hugo-darktable-docs-epub-theme/layouts/partials/css.html
@@ -1,5 +1,5 @@
 <!-- Our custom CSS -->
 <!-- {{ $options := (dict "targetPath" "style.css" "outputStyle" "compressed" "enableSourceMap" true) }} -->
 {{ $options := (dict "targetPath" "style.css" "enableSourceMap" true) }}
-{{ $style := resources.Get "sass/main.scss" | resources.ToCSS $options }}
+{{ $style := resources.Get "sass/main.scss" | css.Sass $options | minify | fingerprint }}
 <link rel="stylesheet" href="{{ $style.Permalink }}" type="text/css" />

--- a/themes/hugo-darktable-docs-epub-theme/layouts/partials/css.html
+++ b/themes/hugo-darktable-docs-epub-theme/layouts/partials/css.html
@@ -1,5 +1,5 @@
 <!-- Our custom CSS -->
 <!-- {{ $options := (dict "targetPath" "style.css" "outputStyle" "compressed" "enableSourceMap" true) }} -->
 {{ $options := (dict "targetPath" "style.css" "enableSourceMap" true) }}
-{{ $style := resources.Get "sass/main.scss" | css.Sass $options | minify | fingerprint }}
+{{ $style := resources.Get "sass/main.scss" | css.Sass $options }}
 <link rel="stylesheet" href="{{ $style.Permalink }}" type="text/css" />

--- a/themes/hugo-darktable-docs-pdf-theme/layouts/partials/css.html
+++ b/themes/hugo-darktable-docs-pdf-theme/layouts/partials/css.html
@@ -1,5 +1,5 @@
 <!-- Our custom CSS -->
 <!-- {{ $options := (dict "targetPath" "style.css" "outputStyle" "compressed" "enableSourceMap" true) }} -->
 {{ $options := (dict "targetPath" "style.css" "enableSourceMap" true) }}
-{{ $style := resources.Get "sass/main.scss" | resources.ToCSS $options | minify | fingerprint }}
+{{ $style := resources.Get "sass/main.scss" | css.Sass $options | minify | fingerprint }}
 <link rel="stylesheet" href="{{ $style.Permalink }}">

--- a/tools/build-all.sh
+++ b/tools/build-all.sh
@@ -13,7 +13,7 @@ cd "$PROJECT_ROOT"
 ./tools/build-html.sh "$base_url"
 
 #build epubs
-#./tools/build-epub.sh
+./tools/build-epub.sh
 
 #build pdfs
-#./tools/build-pdf.sh
+./tools/build-pdf.sh


### PR DESCRIPTION
Relates to: #776

There have been a number of requests for PDF and ePub versions to be available again. I tried some experiments locally and these changes do seem to allow these versions to be created (possibly with some errors, which can be looked at separately).

@TurboGit - a few questions:

1. is this worth doing?
2. do you know who might be able to review this?
3. does the deployment of the generated html, PDF, and ePub versions happen automatically (a github action of some kind)?