### PR TITLE
add link to the comprehensive darktable lua docs

### DIFF
--- a/content/lua/overview.md
+++ b/content/lua/overview.md
@@ -10,4 +10,7 @@ Lua scripts can be used to define actions for darktable to perform when an event
 
 darktable uses Lua version 5.4. Describing the principles and syntax of Lua is beyond the scope of this usermanual. For a detailed introduction see the [Lua reference manual](http://www.lua.org/manual/5.4/manual.html).
 
-The following sections will provide you with a brief introduction to how Lua scripts can be used within darktable.
+The following sections will provide you with a brief introduction to how Lua scripts can be used within darktable. The comprehensive documentation on Lua Scripting in darktable can be found in the [darktable lua documentation](https://docs.darktable.org/lua/stable/).
+
+
+


### PR DESCRIPTION
Should be self explanatory. Always found it confusing the darktables lua docs aren't linked in dtdocs? @wpferguson any objections? 