### PR TITLE
added installation guide for pre-existing lua scripts

### DIFF
--- a/content/lua/installation.md
+++ b/content/lua/installation.md
@@ -1,0 +1,68 @@
+---
+title: installing pre existing scripts
+id: installation
+weight: 15
+draft: false
+author: "people"
+---
+
+## Download and Install
+
+Before you can use existing scripts, they must be installed in darktable. This also installs the script manager, which makes it easier to enable or disable individual scripts from the GUI.
+
+In most cases the Lua scripts can be installed via the GUI, but this depends on your OS and chosen method of installation. 
+
+In any case, darktable should be started at least once to set up its directories.
+
+### Linux Package, AppImage and Flatpak
+
+The Lua scripts can be installed using darktable's UI. Ensure git is installed on your system. If it isn't, use the package manager to install it. In the Lighttable view, expand the lua scripts installer module in the lower-left corner. Ensure that select action: install scripts is selected, then click execute. Restart darktable once for the scripts module to appear in the lower-left corner. 
+
+### Linux Snap Packages
+
+Installation through darktable's gui is currently [broken](https://github.com/darktable-org/darktable/issues/20074), so you will have to take the following approach:
+
+Ensure git is installed on your system. If it isn't, use the package manager to install it. You will have to download the Lua scripts using git, then create the `luarc` to let darktable load the script-manager. Close Darktable, open a terminal and:
+
+    cd ~/snap/darktable/current
+    git clone https://github.com/darktable-org/lua-scripts.git lua
+    echo 'require "tools/script_manager"' >> luarc
+
+Restart darktable twice, and the scripts module should appear in the lower-left corner.
+
+### macOS
+
+Ensure git is installed on your system. If it isn't, use the package manager to install it. Then open a terminal and:
+
+    cd ~/.config/darktable/
+    git clone https://github.com/darktable-org/lua-scripts.git lua
+
+### Windows
+
+Ensure git is installed on your system. Git can be obtained from [git for windows](https://gitforwindows.org/), or using Windows package manager winget inside a command prompt with `winget install git.git`. If you use the gitforwindows.org distribution, install the Git Bash Shell also as it will aid in debugging the scripts if necessary. 
+
+The Lua scripts can now be installed by using darktable's UI. In the Lighttable view, expand the lua scripts installer module in the lower-left corner. Ensure that select action: install scripts is selected, then click execute. Restart darktable once for the scripts module to appear in the lower-left corner.
+
+## Updating
+
+To update the script repository, either use the scripts module GUI or open a terminal or command prompt and run the following commands: 
+
+### Snap
+
+    cd ~/snap/darktable/current/lua
+    git pull
+
+### Flatpak
+
+    cd ~/.var/app/org.darktable.Darktable/config/darktable/lua
+    git pull
+
+### Linux and MacOS
+
+    cd ~/.config/darktable/lua/
+    git pull
+
+### Windows
+
+    cd %LOCALAPPDATA%\darktable\lua
+    git pull

--- a/content/lua/installation.md
+++ b/content/lua/installation.md
@@ -8,9 +8,7 @@ author: "people"
 
 ## Download and Install
 
-A collection of scripts is available in the [lua-scripts repository](https://github.com/darktable-org/lua-scripts). This also includes the script manager, which makes it easier to enable or disable individual scripts from the GUI. To use these existing scripts, they must be installed in darktable.
-
-In most cases the Lua scripts can be installed via the GUI, but this depends on your OS and chosen method of installation. 
+A collection of scripts is available in the [lua-scripts repository](https://github.com/darktable-org/lua-scripts). This also includes the script manager, which makes it easier to enable or disable individual scripts from the GUI. To use these existing scripts, they must be installed in darktable. This can in most cases be done within darktable's GUI, but depends on your OS and chosen method of installation. 
 
 In any case, darktable should be started at least once to set up its directories.
 

--- a/content/lua/installation.md
+++ b/content/lua/installation.md
@@ -1,9 +1,7 @@
 ---
-title: installing pre existing scripts
+title: installing pre-existing scripts
 id: installation
 weight: 15
-draft: false
-author: "people"
 ---
 
 ## Download and Install
@@ -14,13 +12,13 @@ In any case, darktable should be started at least once to set up its directories
 
 ### Linux Package, AppImage and Flatpak
 
-The Lua scripts can be installed using darktable's UI. Ensure git is installed on your system. If it isn't, use the package manager to install it. In the Lighttable view, expand the lua scripts installer module in the lower-left corner. Ensure that select action: install scripts is selected, then click execute. Restart darktable once for the scripts module to appear in the lower-left corner. 
+The Lua scripts can be installed using darktable's GUI. Ensure git is installed on your system. If it isn't, use the package manager to install it. In the Lighttable view, expand the lua scripts installer module in the lower-left corner. Ensure that select action: install scripts is selected, then click execute. Restart darktable once for the scripts module to appear in the lower-left corner. 
 
 ### Linux Snap Packages
 
-Installation through darktable's gui is currently [broken](https://github.com/darktable-org/darktable/issues/20074), so you will have to take the following approach:
+Installation through darktable's GUI is currently [broken](https://github.com/darktable-org/darktable/issues/20074), so you will have to take the following approach:
 
-Ensure git is installed on your system. If it isn't, use the package manager to install it. You will have to download the Lua scripts using git, then create the `luarc` to let darktable load the script-manager. Close Darktable, open a terminal and:
+Ensure git is installed on your system. If it isn't, use the package manager to install it. You will have to download the Lua scripts using git, then create the `luarc` to let darktable load the script-manager. Close darktable, open a terminal and: 
 
     cd ~/snap/darktable/current
     git clone https://github.com/darktable-org/lua-scripts.git lua
@@ -39,7 +37,7 @@ Ensure git is installed on your system. If it isn't, use the package manager to 
 
 Ensure git is installed on your system. Git can be obtained from [git for windows](https://gitforwindows.org/), or using Windows package manager winget inside a command prompt with `winget install git.git`. If you use the gitforwindows.org distribution, install the Git Bash Shell also as it will aid in debugging the scripts if necessary. 
 
-The Lua scripts can now be installed by using darktable's UI. In the Lighttable view, expand the lua scripts installer module in the lower-left corner. Ensure that select action: install scripts is selected, then click execute. Restart darktable once for the scripts module to appear in the lower-left corner.
+The Lua scripts can now be installed by using darktable's GUI. In lighttable view, expand the lua scripts installer module in the lower-left corner. Ensure that select action: install scripts is selected, then click execute. Restart darktable once for the scripts module to appear in the lower-left corner.
 
 ## Updating
 

--- a/content/lua/installation.md
+++ b/content/lua/installation.md
@@ -8,7 +8,7 @@ author: "people"
 
 ## Download and Install
 
-Before you can use existing scripts, they must be installed in darktable. This also installs the script manager, which makes it easier to enable or disable individual scripts from the GUI.
+A collection of scripts is available in the [lua-scripts repository](https://github.com/darktable-org/lua-scripts). This also includes the script manager, which makes it easier to enable or disable individual scripts from the GUI. To use these existing scripts, they must be installed in darktable.
 
 In most cases the Lua scripts can be installed via the GUI, but this depends on your OS and chosen method of installation. 
 

--- a/content/lua/installation.md
+++ b/content/lua/installation.md
@@ -28,7 +28,9 @@ Restart darktable twice, and the scripts module should appear in the lower-left 
 
 ### macOS
 
-Ensure git is installed on your system. If it isn't, use the package manager to install it. Then open a terminal and:
+The Lua scripts can be installed by using darktable's GUI. In lighttable view, expand the lua scripts installer module in the lower-left corner. Ensure that select action: install scripts is selected, then click execute. Restart darktable once for the scripts module to appear in the lower-left corner.
+
+Alternatively you could use the console. Ensure git is installed on your system. If it isn't, use the package manager to install it. Then open a terminal and:
 
     cd ~/.config/darktable/
     git clone https://github.com/darktable-org/lua-scripts.git lua


### PR DESCRIPTION
Added an installation guide for Lua in dt to the docs based on the [dt-lua-docs](https://docs.darktable.org/lua/stable/lua.scripts.manual/installation/). These are fairly out of date and could either reference this guide in the future or be synced to it? @wpferguson could you take a look at this? 
