### PR TITLE
Enable in-page table of contents to display

### DIFF
--- a/themes/hugo-darktable-docs-theme/layouts/partials/table-of-contents.html
+++ b/themes/hugo-darktable-docs-theme/layouts/partials/table-of-contents.html
@@ -1,5 +1,5 @@
 <a data-toggle="collapse" href="#collapseTOC" role="button" aria-expanded="false" aria-controls="collapseTOC">
-  {{ i18n "table-of-contents" . }}
+  {{ i18n "table-of-contents" | default "Table of Contents" }}
 </a>
 <div class="collapse" id="collapseTOC">
     <div class="card card-body">


### PR DESCRIPTION
Relates to dtdocs issue: https://github.com/darktable-org/dtdocs/issues/809

A dtdocs issue was raised a while ago about the in-page _table of contents_ not displaying. The _filmic rgb_ page, for instance, has table of contents enabled (`include_toc: true`), but nothing displays.

Looking at the generated html, I see that there _**is**_ a table of contents div created, but the anchor tag to expand it has no text, so nothing is displayed.

This PR adds a default translation which means that _Table of Contents_ is displayed, and clicking it expands or collapses the table.

It is not used in many places, but we may as well have it working.
