### PR TITLE
added instructions per OS how to invoke darktable

### DIFF
--- a/content/special-topics/program-invocation/darktable.md
+++ b/content/special-topics/program-invocation/darktable.md
@@ -4,9 +4,9 @@ id: darktable
 weight: 10
 ---
 
-The `darktable` binary starts darktable with its GUI and full functionality. This is the standard way to use darktable.
+The `darktable` binary starts darktable with its GUI and full functionality. This is the standard way to use darktable. The exact command to launch the binary [depends on your OS](../../special-topics/program-invocation/invocation-per-OS.md).
 
-`darktable` can called with the following command line parameters:
+The following command line parameters are available:
 
 ```
 darktable [-d {all,act_on,cache,camctl,camsupport,common,control,

--- a/content/special-topics/program-invocation/darktable.md
+++ b/content/special-topics/program-invocation/darktable.md
@@ -4,7 +4,7 @@ id: darktable
 weight: 10
 ---
 
-The `darktable` binary starts darktable with its GUI and full functionality. This is the standard way to use darktable. The exact command to launch the binary [depends on your OS](../../special-topics/program-invocation/invocation-per-OS.md).
+The `darktable` binary starts darktable with its GUI and full functionality. This is the standard way to use darktable. The command to run the binary [depends on your OS](../../special-topics/program-invocation/invocation-per-OS.md).
 
 The following command line parameters are available:
 

--- a/content/special-topics/program-invocation/invocation-per-OS.md
+++ b/content/special-topics/program-invocation/invocation-per-OS.md
@@ -12,6 +12,7 @@ Linux
      + To run e.g. `darktable-cltest`: `flatpak run --command=darktable-cli org.darktable.Darktable --arguments-go-here`
 * AppImage: Navigate to containing folder, then `./darktable.Appimage` (or however you named the file). 
      + To run e.g. `darktable-cltest`: `./darktable.Appimage darktable-cltest`
+     + An additional option to run the various binaries included in darktable (e.g. `darktable-cltest` or `darktable-cli`) you can also use a symbolic link: Create a symbolic link to your AppImage and call it e.g. `darktable-cli`. Then, when calling the AppImage through the symbolic link with `./darktable-cli`, the code inside the package checks to see if there is a binary file inside the AppImage with a name that matches the symlink name, and if so, it will be run instead of the default one.
      
 Windows
 * Navigate to darktable's program folder: `cd "\Program Files\darktable\bin"`
@@ -22,4 +23,4 @@ macOS
 * `/Applications/darktable.app/Contents/MacOS/darktable`
 * The other binaries e.g. `darktable-cltest` are also located in this folder and can be called accordingly
 
-Command line options are in any case simply appended. 
+Command line options are in any case simply appended. (e.g. `-d common`).

--- a/content/special-topics/program-invocation/invocation-per-OS.md
+++ b/content/special-topics/program-invocation/invocation-per-OS.md
@@ -1,0 +1,23 @@
+---
+title: invocation per OS
+id: invocation-per-os
+weight: 5
+---
+
+`darktable` and the other binaries (e.g. `darktable-cltest`) can be called from the console as follows:
+
+Linux
+* Installed as package or snap: `darktable`
+* Flatpak: `flatpak run org.darktable.Darktable`. 
+     + To run e.g. `darktable-cltest`: `flatpak run --command=darktable-cli org.darktable.Darktable --arguments-go-here`
+* AppImage: Navigate to containing folder, then `./darktable.Appimage` (or however you named the file). 
+     + To run e.g. `darktable-cltest`: `./darktable.Appimage darktable-cltest`
+     
+Windows
+* Navigate to darktable's program folder: `cd "\Program Files\darktable\bin"`
+* Then `.\darktable.exe` 
+* the other binaries e.g. `darktable-cltest.exe` are also located in this folder and can be called accordingly
+
+macOS
+* `/Applications/darktable.app/Contents/MacOS/darktable`
+* The other binaries e.g. `darktable-cltest` are also located in this folder and can be called accordingly

--- a/content/special-topics/program-invocation/invocation-per-OS.md
+++ b/content/special-topics/program-invocation/invocation-per-OS.md
@@ -12,7 +12,9 @@ Linux
      + To run e.g. `darktable-cltest`: `flatpak run --command=darktable-cli org.darktable.Darktable --arguments-go-here`
 * AppImage: Navigate to containing folder, then `./darktable.Appimage` (or however you named the file). 
      + To run e.g. `darktable-cltest`: `./darktable.Appimage darktable-cltest`
-     + An additional option to run the various binaries included in darktable (e.g. `darktable-cltest` or `darktable-cli`) is through a symbolic link: Create a symbolic link to your AppImage and call it e.g. `darktable-cli`. Then, when calling the AppImage through the symbolic link with `./darktable-cli`, the code inside the package checks to see if there is a binary file inside the AppImage with a name that matches the symlink name, and if so, it will be run instead of the default one.
+     + An additional option to run the various binaries included in darktable (e.g. `darktable-cltest` or `darktable-cli`) is through a symbolic link: 
+          * Create a symbolic link to your AppImage and call it e.g. `darktable-cli`. 
+          * Then, when calling the AppImage through the symbolic link with `./darktable-cli`, the code inside the package checks to see if there is a binary file inside the AppImage with a name that matches the symlink name, and if so, it will be run instead of the default one.
      
 Windows
 * Navigate to darktable's program folder: `cd "\Program Files\darktable\bin"`

--- a/content/special-topics/program-invocation/invocation-per-OS.md
+++ b/content/special-topics/program-invocation/invocation-per-OS.md
@@ -4,25 +4,24 @@ id: invocation-per-os
 weight: 5
 ---
 
-`darktable` and the other binaries (e.g. `darktable-cltest`) can be called from the console as follows:
+`darktable` and the other binaries (e.g. `darktable-cltest`) can be executed from the console as follows:
 
 Linux
 * Installed as package or snap: `darktable`
-* Flatpak: `flatpak run org.darktable.Darktable`. 
-     + To run e.g. `darktable-cltest`: `flatpak run --command=darktable-cli org.darktable.Darktable --arguments-go-here`
-* AppImage: Navigate to containing folder, then `./darktable.Appimage` (or however you named the file). 
+* Flatpak: `flatpak run org.darktable.Darktable`
+     + To run e.g. `darktable-cltest`: `flatpak run --command=darktable-cltest org.darktable.Darktable --arguments-go-here`.
+* AppImage: Navigate to containing folder, then `./darktable.Appimage` (or however you named the file)
      + To run e.g. `darktable-cltest`: `./darktable.Appimage darktable-cltest`
      + An additional option to run the various binaries included in darktable (e.g. `darktable-cltest` or `darktable-cli`) is through a symbolic link: 
-          * Create a symbolic link to your AppImage and call it e.g. `darktable-cli`. 
-          * Then, when calling the AppImage through the symbolic link with `./darktable-cli`, the code inside the package checks to see if there is a binary file inside the AppImage with a name that matches the symlink name, and if so, it will be run instead of the default one.
+          * Create a symbolic link to your AppImage and call it e.g. `darktable-cli`.
+          * Then, when calling the AppImage through the symbolic link with `./darktable-cli`, the code inside the package checks if there is a binary file inside the AppImage with a name that matches the symlink name. If so, it will be run instead of the default one..
      
 Windows
-* Navigate to darktable's program folder: `cd "\Program Files\darktable\bin"`
-* Then `.\darktable.exe` 
-* The other binaries e.g. `darktable-cltest.exe` are also located in this folder and can be called accordingly
+* Navigate to darktable's program folder: `cd "\Program Files\darktable\bin"` then execute `.\darktable.exe`. 
+* The other binaries e.g. `darktable-cltest.exe` are also located in this folder and can be called accordingly.
 
 macOS
-* `/Applications/darktable.app/Contents/MacOS/darktable`
-* The other binaries e.g. `darktable-cltest` are also located in this folder and can be called accordingly
+* Execute `/Applications/darktable.app/Contents/MacOS/darktable`.
+* The other binaries e.g. `darktable-cltest` are also located in this folder and can be called accordingly.
 
 Command line options are in any case simply appended. (e.g. `-d common`).

--- a/content/special-topics/program-invocation/invocation-per-OS.md
+++ b/content/special-topics/program-invocation/invocation-per-OS.md
@@ -16,8 +16,10 @@ Linux
 Windows
 * Navigate to darktable's program folder: `cd "\Program Files\darktable\bin"`
 * Then `.\darktable.exe` 
-* the other binaries e.g. `darktable-cltest.exe` are also located in this folder and can be called accordingly
+* The other binaries e.g. `darktable-cltest.exe` are also located in this folder and can be called accordingly
 
 macOS
 * `/Applications/darktable.app/Contents/MacOS/darktable`
 * The other binaries e.g. `darktable-cltest` are also located in this folder and can be called accordingly
+
+Command line options are in any case simply appended. 

--- a/content/special-topics/program-invocation/invocation-per-OS.md
+++ b/content/special-topics/program-invocation/invocation-per-OS.md
@@ -12,7 +12,7 @@ Linux
      + To run e.g. `darktable-cltest`: `flatpak run --command=darktable-cli org.darktable.Darktable --arguments-go-here`
 * AppImage: Navigate to containing folder, then `./darktable.Appimage` (or however you named the file). 
      + To run e.g. `darktable-cltest`: `./darktable.Appimage darktable-cltest`
-     + An additional option to run the various binaries included in darktable (e.g. `darktable-cltest` or `darktable-cli`) you can also use a symbolic link: Create a symbolic link to your AppImage and call it e.g. `darktable-cli`. Then, when calling the AppImage through the symbolic link with `./darktable-cli`, the code inside the package checks to see if there is a binary file inside the AppImage with a name that matches the symlink name, and if so, it will be run instead of the default one.
+     + An additional option to run the various binaries included in darktable (e.g. `darktable-cltest` or `darktable-cli`) is through a symbolic link: Create a symbolic link to your AppImage and call it e.g. `darktable-cli`. Then, when calling the AppImage through the symbolic link with `./darktable-cli`, the code inside the package checks to see if there is a binary file inside the AppImage with a name that matches the symlink name, and if so, it will be run instead of the default one.
      
 Windows
 * Navigate to darktable's program folder: `cd "\Program Files\darktable\bin"`


### PR DESCRIPTION
The docs were missing OS-specific instructions on how to invoke darktable and the other binaries like darktable-cltest. 

Cannot test mac, would be grateful if someone else could do that. I did test snap, flatpak, appimage, package and windows.