### PR TITLE
Document AI features: preferences tab and special-topics section

### DIFF
--- a/content/preferences-settings/ai.md
+++ b/content/preferences-settings/ai.md
@@ -1,0 +1,76 @@
+---
+title: AI
+id: ai
+weight: 135
+---
+
+Control darktable's AI features: enable or disable them, choose a hardware accelerator for model inference, point darktable at an ONNX Runtime library, and manage the AI models available on disk.
+
+AI features are powered by [ONNX Runtime](https://onnxruntime.ai/). darktable ships with a CPU-only ONNX Runtime on Linux, a DirectML-enabled build on Windows, and a CoreML-enabled build on macOS. To enable NVIDIA, AMD or Intel GPU acceleration on Linux or Windows, install a GPU-enabled ONNX Runtime using the install scripts described below.
+
+For a deeper explanation of how AI features work – the inference runtime, execution providers, model layout, GPU acceleration, and troubleshooting – see the [AI features](../special-topics/ai/) special topic.
+
+# general
+
+enable AI features
+: Master switch for all AI features. When disabled, no ONNX Runtime is loaded, no model directories are scanned, and AI-dependent modules hide themselves. Turn this off to eliminate AI-related memory and startup cost when you don't need it (default off).
+
+AI acceleration
+: The hardware accelerator used for model inference. The list is filtered to show only the providers the currently-loaded ONNX Runtime actually supports – installing a different ONNX Runtime updates the list.
+
+: - _auto_ picks the best available provider for the loaded library, falling back to CPU if no accelerator initialises.
+: - _CPU_ runs inference on the processor. Always available.
+: - _NVIDIA CUDA_ uses NVIDIA GPUs via cuDNN (Linux, Windows; requires a CUDA-enabled ONNX Runtime).
+: - _AMD MIGraphX_ uses AMD GPUs via ROCm (Linux only; requires a MIGraphX-enabled ONNX Runtime).
+: - _Intel OpenVINO_ uses Intel GPUs and iGPUs via OpenVINO (Linux, Windows; requires an OpenVINO-enabled ONNX Runtime).
+: - _Windows DirectML_ uses any DirectX 12 capable GPU (Windows; bundled by default).
+: - _Apple CoreML_ uses the Apple Neural Engine and integrated GPU (macOS; bundled by default).
+
+: Double-click the label to reset to the default. If the selected provider cannot be initialised with the currently-loaded ONNX Runtime (for example, if the library was built without that provider) a _not available, will fall back to CPU_ notice appears next to the combo box. After swapping the ONNX Runtime library, the notice becomes _restart to apply_ until darktable is restarted.
+
+ONNX Runtime library
+: Path to a shared library (`libonnxruntime.so*` on Linux, `onnxruntime.dll` on Windows) that darktable should load in place of the bundled one. Leave empty to use the bundled library (CPU-only on Linux, DirectML on Windows). Double-click the label to reset to empty. Changes take effect after restarting darktable. _Hidden on macOS_, where ONNX Runtime is statically linked with CoreML support.
+
+: To the right of the path field are two buttons:
+
+: - _browse_ (folder icon) – open a file chooser to pick a custom ONNX Runtime library. Selection is validated by loading the library and probing its version and available execution providers; if the file is not a valid ONNX Runtime build it is rejected and the previous path is restored.
+
+: - _detect_ – scan standard system locations for an ONNX Runtime library (package-manager installs, `/usr/lib`, `/usr/local/lib`, `~/.local/lib`). If multiple candidates are found you will be asked to choose; if exactly one is found it is applied automatically. Useful when you have installed ONNX Runtime via your distribution's package manager or via the install script described below.
+
+# installing a GPU ONNX Runtime
+
+GPU acceleration on Linux and Windows (NVIDIA CUDA, AMD MIGraphX, Intel OpenVINO) requires a GPU-enabled ONNX Runtime build, which darktable does not ship in-app. Install scripts handle this end-to-end – detecting your GPU, downloading the matching runtime, verifying it, and installing under your user account.
+
+See [GPU acceleration](../special-topics/ai/gpu-acceleration.md) for the full instructions: one-line installers for Linux and Windows, prerequisites, GPU and driver requirements, alternative manual installation, building AMD ONNX Runtime from source, and troubleshooting.
+
+After installation, restart darktable, then use the _detect_ button above to point darktable at the newly-installed library (or pick the file manually with the browse button).
+
+# models
+
+The lower half of the tab lists AI models known to darktable – both already-downloaded ones and those available from the [darktable-ai](https://github.com/darktable-org/darktable-ai) model repository.
+
+model list
+: Each row has the following columns:
+
+: - _select_ (leftmost checkbox) – include the model in bulk operations (_download selected_, _delete selected_). Independent of the enabled state. The header checkbox toggles all rows at once.
+: - _name_ – model name.
+: - info button (_i_ icon) – click to open the model card with full metadata: scope, author, source, paper, license, training data, data license, notes.
+: - _version_ – model version string from the repository manifest.
+: - _task_ – which task this model serves: _mask_, _denoise_, _rawdenoise_, _upscale_.
+: - _enabled_ – marks the model as the active model for its task. Only one model can be active per task at a time: ticking it on a second model of the same task automatically un-ticks the previously active one, like a radio button. Un-ticking the active model leaves the task with no active model until another is picked. AI-dependent modules use whichever model is currently active for their task.
+: - _status_ – _downloaded_, _not downloaded_, _update available_, or _update required_.
+: - _default_ – _yes_ if the model is in the developer-recommended default set (selected by _download default_), _no_ otherwise.
+
+download / update default
+: Download or update the subset of models the darktable developers recommend as defaults for each task. Useful to get going quickly with a fresh install, and to pull in any newer versions of those models that the repository has published since.
+
+download / update selected
+: Download or update the models whose _select_ checkbox is ticked. Use this when you've ticked one or a few specific models in the list and only want to operate on those.
+
+import from file…
+: Install a model from a local `.dtmodel` archive. The file chooser is filtered to `*.dtmodel`; once imported, the model immediately becomes available. Use this for models you've been given by hand, models you've built yourself, or extra per-task alternatives from the [darktable-ai](https://github.com/darktable-org/darktable-ai) repository – the in-app list shows only one or two models per task, but the repository may publish additional alternatives for the same task (different denoise model trained on a different dataset, alternative segmentation backbone, etc.). Download the `.dtmodel` from the repository's GitHub releases and import it here.
+
+delete selected
+: Remove the models whose _select_ checkbox is ticked from disk. Models that were bundled with darktable cannot be deleted.
+
+Downloads run in the background with a progress dialog and can be cancelled. Failed downloads are reported and the affected models remain in their previous state.

--- a/content/preferences-settings/ai.md
+++ b/content/preferences-settings/ai.md
@@ -6,7 +6,15 @@ weight: 135
 
 Control darktable's AI features: enable or disable them, choose a hardware accelerator for model inference, point darktable at an ONNX Runtime library, and manage the AI models available on disk.
 
-AI features are powered by [ONNX Runtime](https://onnxruntime.ai/). darktable ships with a CPU-only ONNX Runtime on Linux, a DirectML-enabled build on Windows, and a CoreML-enabled build on macOS. To enable NVIDIA, AMD or Intel GPU acceleration on Linux or Windows, install a GPU-enabled ONNX Runtime using the install scripts described below.
+AI features are powered by [ONNX Runtime](https://onnxruntime.ai/). What runs out of the box and what GPU acceleration can be added on each platform:
+
+| OS      | Bundled                                    | Optional GPU acceleration                  |
+|---------|--------------------------------------------|--------------------------------------------|
+| Linux   | CPU only                                   | NVIDIA CUDA, AMD ROCm/MIGraphX, Intel OpenVINO |
+| Windows | DirectML (any DirectX 12 GPU)              | NVIDIA CUDA, Intel OpenVINO                |
+| macOS   | CoreML (Apple Silicon, integrated GPU)     | –                                          |
+
+Install scripts for the GPU runtimes are described below; see [GPU acceleration](../special-topics/ai/gpu-acceleration.md) for the full instructions.
 
 For a deeper explanation of how AI features work – the inference runtime, execution providers, model layout, GPU acceleration, and troubleshooting – see the [AI features](../special-topics/ai/) special topic.
 
@@ -16,20 +24,20 @@ enable AI features
 : Master switch for all AI features. When disabled, no ONNX Runtime is loaded, no model directories are scanned, and AI-dependent modules hide themselves. Turn this off to eliminate AI-related memory and startup cost when you don't need it (default off).
 
 AI acceleration
-: The hardware accelerator used for model inference. The list is filtered to show only the providers the currently-loaded ONNX Runtime actually supports – installing a different ONNX Runtime updates the list.
+: The hardware accelerator used for model inference. The list only shows the currently available providers as supported by the loaded ONNX Runtime. Installing a different ONNX Runtime updates the list.
 
 : - _auto_ picks the best available provider for the loaded library, falling back to CPU if no accelerator initialises.
 : - _CPU_ runs inference on the processor. Always available.
-: - _NVIDIA CUDA_ uses NVIDIA GPUs via cuDNN (Linux, Windows; requires a CUDA-enabled ONNX Runtime).
-: - _AMD MIGraphX_ uses AMD GPUs via ROCm (Linux only; requires a MIGraphX-enabled ONNX Runtime).
-: - _Intel OpenVINO_ uses Intel GPUs and iGPUs via OpenVINO (Linux, Windows; requires an OpenVINO-enabled ONNX Runtime).
+: - _NVIDIA CUDA_ uses NVIDIA GPUs via cuDNN (Linux, Windows; requires installing a CUDA-enabled ONNX Runtime).
+: - _AMD MIGraphX_ uses AMD GPUs via ROCm (Linux only; requires installing a MIGraphX-enabled ONNX Runtime).
+: - _Intel OpenVINO_ uses Intel GPUs and iGPUs via OpenVINO (Linux, Windows; requires installing an OpenVINO-enabled ONNX Runtime).
 : - _Windows DirectML_ uses any DirectX 12 capable GPU (Windows; bundled by default).
 : - _Apple CoreML_ uses the Apple Neural Engine and integrated GPU (macOS; bundled by default).
 
 : Double-click the label to reset to the default. If the selected provider cannot be initialised with the currently-loaded ONNX Runtime (for example, if the library was built without that provider) a _not available, will fall back to CPU_ notice appears next to the combo box. After swapping the ONNX Runtime library, the notice becomes _restart to apply_ until darktable is restarted.
 
 ONNX Runtime library
-: Path to a shared library (`libonnxruntime.so*` on Linux, `onnxruntime.dll` on Windows) that darktable should load in place of the bundled one. Leave empty to use the bundled library (CPU-only on Linux, DirectML on Windows). Double-click the label to reset to empty. Changes take effect after restarting darktable. _Hidden on macOS_, where ONNX Runtime is statically linked with CoreML support.
+: Path to a shared library (`libonnxruntime.so*` on Linux, `onnxruntime.dll` on Windows) that darktable should load in place of the bundled one. Leave empty to use the bundled library (see the table above for what that is per OS). To use a GPU runtime, install one via the scripts described below and point this field at it. Double-click the label to reset to empty. Changes take effect after restarting darktable. _Hidden on macOS_, where ONNX Runtime is statically linked with CoreML support.
 
 : To the right of the path field are two buttons:
 

--- a/content/special-topics/ai/_index.md
+++ b/content/special-topics/ai/_index.md
@@ -1,0 +1,5 @@
+---
+title: AI features
+id: ai-features
+weight: 32
+---

--- a/content/special-topics/ai/gpu-acceleration.md
+++ b/content/special-topics/ai/gpu-acceleration.md
@@ -1,0 +1,130 @@
+---
+title: GPU acceleration
+id: gpu-acceleration
+weight: 30
+---
+
+Enabling GPU acceleration for darktable's AI features is a two-step process:
+
+1. **Install a GPU-capable ONNX Runtime** for your hardware (this page).
+2. **Point darktable at the new library** via [AI preferences](../../../preferences-settings/ai.md) – click **detect** to auto-scan standard install locations, or browse to the file by hand.
+
+The runtime bundled with darktable is CPU-only on Linux, DirectML-enabled on Windows, and CoreML-enabled on macOS, so step 1 only applies if you want NVIDIA, AMD, or Intel GPU acceleration on Linux or Windows. Step 1 has three paths, covered below.
+
+# requirements
+
+The bundled providers on Windows (DirectML, any DirectX 12 GPU) and macOS (CoreML, Apple Silicon or recent Intel Mac) have no extra requirements. The Linux/Windows GPU providers below need supported hardware and a few system libraries already in place.
+
+**NVIDIA (CUDA)**
+: Pascal-or-newer GPU (compute capability 6.0+). [NVIDIA driver](https://www.nvidia.com/Download/index.aspx) 525 or later. Plus **one of** [CUDA Toolkit 12.x](https://developer.nvidia.com/cuda-12-9-0-download-archive) or [CUDA Toolkit 13.x](https://developer.nvidia.com/cuda-downloads) and [cuDNN](https://developer.nvidia.com/cudnn-downloads) 9.x installed on the system. The two CUDA branches have separate ONNX Runtime builds and you need the one that matches the toolkit version installed on your machine.
+
+: To check what CUDA toolkit you have:
+
+: - run `nvcc --version` in a terminal – the `release` line tells you the installed toolkit (e.g. `release 12.6` means CUDA 12 is installed).
+: - `nvidia-smi` reports a `CUDA Version:` field at the top, but that is the **maximum** version the driver is capable of running, not what's installed. A machine with driver 580+ might show `CUDA Version: 13.2` while actually having only CUDA 12 installed via `nvcc`.
+
+: If you have CUDA 12 installed and want to switch to 13, install the CUDA 13 toolkit (in parallel with 12 is fine) and then re-run the ONNX Runtime install script – it picks the build matching the toolkit it finds.
+
+**AMD (MIGraphX)** _(Linux only)_
+: ROCm-supported GPU (Radeon RX 7700-series or newer, Instinct MI100 or newer). [ROCm](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/) 6.x or newer with MIGraphX installed on the system.
+
+: Note: the first inference of each model on MIGraphX takes minutes because the model graph is compiled for your specific GPU and then cached on disk – see the [performance notes](../performance-and-troubleshooting/#performance-notes) for details. Once cached, subsequent runs are fast and survive across darktable restarts.
+
+**Intel (OpenVINO)**
+: Intel iGPU (HD / UHD / Iris Xe) or Arc discrete GPU. [Intel GPU driver](https://www.intel.com/content/www/us/en/download-center/home.html) with [OpenCL](https://github.com/intel/compute-runtime) (`intel-opencl-icd`) and/or [Level Zero](https://github.com/oneapi-src/level-zero). OpenVINO itself ships in the install package – nothing extra to install.
+
+If a required system library is missing, the install script will tell you which one and point you at the vendor's install docs. The package still installs; acceleration only kicks in once the missing library is in place.
+
+# use the install scripts (recommended)
+
+The simplest path: paste one line into a terminal. The script figures out which GPU you have, downloads the matching ONNX Runtime build, verifies it, and installs it under your user account. No root, no source checkout.
+
+Linux:
+```bash
+curl -fsSL https://raw.githubusercontent.com/darktable-org/darktable/HEAD/tools/ai/install-ort-gpu.sh | bash
+```
+
+Windows (PowerShell):
+```powershell
+irm https://raw.githubusercontent.com/darktable-org/darktable/HEAD/tools/ai/install-ort-gpu.ps1 | iex
+```
+
+The Linux script needs `bash`, `curl`, `jq`, `tar`, and `unzip` available on `PATH` – if any are missing it tells you which ones up front so the install doesn't fail halfway through. The Windows script needs PowerShell 5.1 or newer (preinstalled on Windows 10+).
+
+If you have more than one GPU, the script asks which one to target. If your GPU needs system libraries that aren't installed (cuDNN on NVIDIA, MIGraphX on AMD), the script tells you what's missing and where to get it – the install still completes, but acceleration only kicks in once those system libraries are in place.
+
+To force a specific execution provider instead of letting the script auto-detect, pass `--ep` (bash) or `-Ep` (PowerShell). Values: `cuda12`, `cuda13`, `rocm`, `migraphx`, `openvino`. Useful when both NVIDIA and Intel GPUs are present and you want a specific one, or when `nvcc` is not installed and the script can't tell whether you have CUDA 12 or CUDA 13 on the system.
+
+When the script finishes, restart darktable, open [AI preferences](../../../preferences-settings/ai.md), and click **detect** so darktable picks up the newly-installed runtime. Then choose your provider (CUDA, MIGraphX, OpenVINO) under _AI acceleration_.
+
+# detect a system-installed ONNX Runtime
+
+If your distribution already ships a GPU-capable ONNX Runtime (common on Arch, occasionally on Ubuntu/Debian via third-party repos), just click **detect** in the AI preferences tab – darktable looks in standard system locations and configures itself.
+
+# install manually
+
+When the automatic options don't fit (locked-down environment, custom audit, GitHub API rate-limited – see below) you can fetch and place the files yourself. The goal is a `libonnxruntime.so.*` / `onnxruntime.dll` on disk that darktable can be pointed at via the _ONNX Runtime library_ field in AI preferences.
+
+## where to download
+
+| Vendor | Source |
+|--------|--------|
+| NVIDIA CUDA 12 | [GitHub Releases](https://github.com/microsoft/onnxruntime/releases/latest) – `onnxruntime-{linux\|win}-x64-gpu-X.Y.Z.{tgz\|zip}` |
+| NVIDIA CUDA 13 | [GitHub Releases](https://github.com/microsoft/onnxruntime/releases/latest) – `onnxruntime-{linux\|win}-x64-gpu_cuda13-X.Y.Z.{tgz\|zip}` |
+| AMD ROCm 6.x | [PyPI `onnxruntime-rocm`](https://pypi.org/project/onnxruntime-rocm/#files) – `cp312` `manylinux` wheel |
+| AMD ROCm 7.x | [PyPI `onnxruntime-migraphx`](https://pypi.org/project/onnxruntime-migraphx/#files) – `cp312` `manylinux` wheel |
+| Intel OpenVINO (Linux) | [PyPI `onnxruntime-openvino`](https://pypi.org/project/onnxruntime-openvino/#files) – `cp312` `manylinux_2_28_x86_64` wheel |
+| Intel OpenVINO (Windows) | [PyPI `onnxruntime-openvino`](https://pypi.org/project/onnxruntime-openvino/#files) + [PyPI `openvino`](https://pypi.org/project/openvino/#files) – both `cp312` `win_amd64` |
+
+NVIDIA tarballs/zips are simplest to extract: the library sits under `lib/`. PyPI wheels (`.whl` files are renamed zips) carry the library under `<package>/capi/` along with the `LICENSE` and `ThirdPartyNotices.txt` you should keep next to it. AMD wheels may additionally ship a sibling `<package>.libs/` directory of auditwheel-bundled ROCm libs – when present, that directory must stay alongside `libonnxruntime.so.*` after copying, because the providers' RPATH resolves through a relative `$ORIGIN` reference. Intel on Windows needs DLLs from a second wheel (`openvino`) copied next to `onnxruntime.dll`.
+
+By convention, place the extracted files under `~/.local/lib/onnxruntime-<ep>/` on Linux or `%LOCALAPPDATA%\onnxruntime-<ep>\` on Windows (`<ep>` = `cuda`, `rocm`, `migraphx`, or `openvino`). The **detect** button in AI preferences scans for any `onnxruntime-*` directory under those roots.
+
+## AMD: alternative source when PyPI's GPU coverage isn't enough
+
+PyPI's `onnxruntime-rocm` / `onnxruntime-migraphx` wheels ship HIP kernel binaries for a fixed set of GPU architectures. If your card's `gfx*` ID isn't covered, ONNX Runtime loads but model compilation fails at runtime:
+
+```
+migraphx_program_compile: Error: ... no kernel image is available
+for execution on the device
+```
+
+This commonly hits some RDNA 3 iGPUs (e.g. Radeon 780M / gfx1103). Two cheaper workarounds before reinstalling:
+
+- **hide the unsupported GPU** from MIGraphX so it binds to a supported card (find indices with `rocminfo | grep -E "Marketing Name|gfx"`):
+  ```bash
+  HIP_VISIBLE_DEVICES=0 darktable
+  ```
+- **override the gfx version** – RDNA 3 is mostly binary-compatible with gfx1100, so the bundled kernels often work:
+  ```bash
+  HSA_OVERRIDE_GFX_VERSION=11.0.0 darktable
+  ```
+
+If neither helps, AMD's own ROCm repository ships builds with broader per-architecture coverage. Browse https://repo.radeon.com/rocm/manylinux/, find the `rocm-rel-X.Y.Z/` directory matching your installed ROCm version, download the `cp312` `onnxruntime_rocm-*.whl`, and extract it the same way as the PyPI wheel.
+
+## building AMD from source
+
+When even the AMD repository binaries don't match your system (custom-built ROCm, an unusual distro), build ONNX Runtime against your installed ROCm. From a darktable source checkout:
+
+```bash
+./tools/ai/install-ort-amd-build.sh
+```
+
+Needs `cmake` 3.26+, a C++ compiler, `python3`, and `git`. Takes 10–20 minutes.
+
+## GitHub API rate limit
+
+For CUDA 13, the install script asks `api.github.com` which release is latest. GitHub limits unauthenticated callers to **60 requests per hour per source IP**. On shared NAT (corporate networks, VPNs, cloud VMs) that limit gets exhausted quickly by other users on the same IP, and the script fails with a clear message pointing here.
+
+Two ways out:
+
+- **set `GITHUB_TOKEN`** to any personal access token (no scopes required for public repos) before re-running – raises the limit to 5000 requests/hour authenticated.
+- **install manually** – for the CUDA 13 tarball this is `tar xzf` plus a copy. The install script prints the same instructions on failure.
+
+PyPI sources (AMD, Intel, NVIDIA CUDA 12) have no published rate limit and are unaffected.
+
+# after installing a new ONNX Runtime
+
+When darktable starts up with a new ONNX Runtime library, the _AI acceleration_ dropdown in AI preferences re-populates with only the providers that library actually advertises. Older selections that are no longer supported are switched to another available GPU provider automatically, or to _auto_ if no GPU is left.
+
+Between the install and the restart, the dropdown shows a _restart to apply_ hint next to the provider name – a reminder that the currently-loaded runtime is stale.

--- a/content/special-topics/ai/gpu-acceleration.md
+++ b/content/special-topics/ai/gpu-acceleration.md
@@ -9,7 +9,7 @@ Enabling GPU acceleration for darktable's AI features is a two-step process:
 1. **Install a GPU-capable ONNX Runtime** for your hardware (this page).
 2. **Point darktable at the new library** via [AI preferences](../../../preferences-settings/ai.md) – click **detect** to auto-scan standard install locations, or browse to the file by hand.
 
-The runtime bundled with darktable is CPU-only on Linux, DirectML-enabled on Windows, and CoreML-enabled on macOS, so step 1 only applies if you want NVIDIA, AMD, or Intel GPU acceleration on Linux or Windows. Step 1 has three paths, covered below.
+On Linux, the bundled runtime is CPU-only; on Windows, it uses DirectML; and on macOS, it uses CoreML. So, step 1 only applies if you want NVIDIA, AMD, or Intel GPU acceleration on Linux or Windows. Step 1 has three paths, covered below.
 
 # requirements
 

--- a/content/special-topics/ai/how-ai-works.md
+++ b/content/special-topics/ai/how-ai-works.md
@@ -1,0 +1,44 @@
+---
+title: how AI features work
+id: how-ai-works
+weight: 20
+---
+
+This page covers what goes on under the hood: the inference library darktable loads, the execution providers available to it, and how models are stored and activated.
+
+# the inference runtime
+
+darktable loads models through [ONNX Runtime](https://onnxruntime.ai/) – a production-grade inference library originally developed at Microsoft and now governed by the [Linux Foundation](https://www.linuxfoundation.org/) – that accepts models in the [ONNX](https://onnx.ai/) open format. ONNX is the de-facto standard for interchanging machine-learning models across frameworks (PyTorch, TensorFlow, etc.) so we can take a model trained in any of them, export it to ONNX, and run it from darktable without carrying its training framework along.
+
+Only one ONNX Runtime library is loaded per darktable process. It is picked in this order:
+
+1. If the _ONNX Runtime library_ field in [AI preferences](../../../preferences-settings/ai.md) points at a file (or the `DT_ORT_LIBRARY` environment variable does), that library is loaded instead.
+2. Otherwise, the bundled runtime that ships with darktable is loaded from the installation directory.
+
+The bundled runtime is CPU-only on Linux, DirectML-enabled on Windows, and CoreML-enabled on macOS. That makes every install functional out of the box. If you want NVIDIA, AMD or Intel GPU acceleration on Linux or Windows, you replace the library with a GPU-enabled build – see [GPU acceleration](../gpu-acceleration/).
+
+# execution providers
+
+An _execution provider_ (EP) is an ONNX Runtime back-end for a specific hardware accelerator – darktable's _AI acceleration_ preference is this concept. A single ONNX Runtime library can ship with multiple providers; which ones actually work depends on which are compiled into the library and which are available on your system. The preference combo lists only those the currently-loaded library supports:
+
+- **auto** – let ONNX Runtime pick the best provider at inference time, with CPU as the ultimate fallback. Recommended unless you have a reason to override.
+- **CPU** – always available. Fine for object-mask and occasional denoise/upscale. Slow for interactive work and for upscale at 4x.
+- **NVIDIA CUDA** – NVIDIA GPUs on Linux/Windows. Requires a CUDA-enabled ONNX Runtime and the matching CUDA toolkit + cuDNN 9.x on your system.
+- **AMD MIGraphX** – AMD GPUs on Linux. Requires a MIGraphX-enabled ONNX Runtime and a ROCm 6.3+ install. Not supported on Windows.
+- **Intel OpenVINO** – Intel integrated and discrete GPUs on Linux/Windows. The OpenVINO runtime is bundled with the installed package – no separate install needed beyond an up-to-date Intel GPU driver.
+- **Windows DirectML** – any DirectX-12-capable GPU on Windows. Good fallback when a vendor-specific provider is impractical. Bundled.
+- **Apple CoreML** – Apple Silicon (Neural Engine and GPU) and recent Intel Macs. Bundled.
+
+The first time a GPU provider runs a given model, it compiles an optimised version of the model graph for your specific hardware. How long this takes varies a lot by provider: CUDA and DirectML are typically a few seconds; AMD MIGraphX can take **5 to 30 minutes** on the first run of each model, depending on the GPU and the model size. Subsequent uses reuse the compiled graph and run at full speed.
+
+# models
+
+Each AI feature is backed by one or more models per [task](../overview/#tasks). A model is a directory containing an ONNX file and a small `config.json` with metadata (name, task, description, licensing information). Models live under:
+
+- Linux: `~/.local/share/darktable/models/`
+- macOS: `~/Library/Application Support/darktable/models/`
+- Windows: `%APPDATA%\darktable\models\`
+
+darktable scans this directory at startup (and whenever you change models in preferences) to discover what is available. Multiple models can be installed for the same task – for denoise, for example, you might have both the NIND-trained and NAFNet-trained options on disk at once. Only one can be _active_ per task at any time; ticking the enabled checkbox on a second model of the same task automatically un-ticks the previously active one. Modules that consume that task load the model currently marked active.
+
+Models are not bundled with darktable. They are distributed as `.dtmodel` packages from the [darktable-ai](https://github.com/darktable-org/darktable-ai/releases) companion repository. The [AI preferences](../../../preferences-settings/ai.md) tab includes buttons to download the default set directly; for additional per-task models (alternative denoisers, segmentation backbones, etc.), download the `.dtmodel` from the repository's releases page and install it via the _install model_ button in the same tab.

--- a/content/special-topics/ai/overview.md
+++ b/content/special-topics/ai/overview.md
@@ -8,13 +8,15 @@ darktable uses machine learning models for a handful of image-processing tasks: 
 
 AI features are opt-in. They are off by default in a fresh install and can be toggled with a single preference at any time.
 
+AI features also have to be present in the darktable binary. The official builds (Linux AppImage, Windows installer, macOS dmg) all include them. Third-party packagers may ship a build without AI support – in that case the _AI_ tab is absent from preferences entirely. Ask your distribution's package maintainer to enable AI support, or use an official build.
+
 # what the AI features do
 
 ## tasks
 
 A _task_ is a capability slot inside darktable – "produce a mask around the clicked subject", "denoise an RGB image", and so on. Tasks are decoupled from the model that implements them: multiple competing models can live on disk for the same task (the NIND denoiser, the NAFNet denoiser, an experimental third…), but only one of them is _active_ for that task at any given time, and that's the one darktable's modules consume. Switching active model is a one-click toggle in [AI preferences](../../../preferences-settings/ai.md) and requires no changes to any module – the consumer just asks for "the active denoise model" and gets whichever you chose.
 
-This indirection is why the model repository can publish alternative or improved models without darktable needing to know about them ahead of time: pick the model in preferences and every consumer of that task picks it up automatically.
+This setup allows for flexibility so the model repository can publish alternative or improved models without darktable needing to know about them ahead of time: pick the model in preferences and every consumer of that task picks it up automatically.
 
 darktable currently exposes four tasks:
 
@@ -22,7 +24,7 @@ mask
 : Interactive object segmentation. Click on a subject in the darkroom and the model produces a mask around it. Used by the parametric mask machinery to select regions without drawing by hand. Powered by models such as SAM 2.1 and SegNext.
 
 denoise
-: Machine-learning RGB denoise as an alternative to the classical denoise modules. Operates on already-demosaiced RGB, trained on pairs of noisy and clean images. Removes sensor noise without the blocky or smoothed look that can come from traditional filters.
+: Machine-learning RGB denoise as an alternative to the classical denoise modules. Operates on already demosaiced RGB image data, trained on pairs of noisy and clean images. Removes sensor noise without the blocky or smoothed look that can come from traditional filters.
 
 rawdenoise
 : Machine-learning denoise applied directly to the raw CFA mosaic before demosaic, with denoise and demosaic combined into a single inference pass. Saved out as a LinearRaw DNG and re-imported, so downstream darkroom processing is unchanged. Useful when sensor noise needs to be addressed before the demosaic algorithm runs.
@@ -44,8 +46,8 @@ darktable uses _narrow AI_ – small, task-specific models that run on your lapt
 
 Beyond scope, the technical guarantees:
 
-- **No cloud inference.** Every model runs locally on your CPU or GPU. Nothing about your image is sent off-device.
-- **No autonomous edits.** Every AI feature is user-triggered; there's no background AI activity on your library.
-- **No training.** darktable ships pre-trained models and runs inference only. The [darktable-ai](https://github.com/darktable-org/darktable-ai) repository holds the conversion scripts and training notes for anyone who wants to retrain or export a new model.
-- **No automatic updates.** Models are downloaded when you ask for them in preferences; nothing happens in the background.
-- **No analytics.** darktable does not report model use, provider selection, or inference performance anywhere.
+- **No cloud inference:** Every model runs locally on your CPU or GPU. Nothing about your image is sent off-device.
+- **No autonomous edits:** Every AI feature is user-triggered; there's no background AI activity on your library.
+- **No training:** darktable ships pre-trained models and runs inference only. The [darktable-ai](https://github.com/darktable-org/darktable-ai) repository holds the conversion scripts and training notes for anyone who wants to retrain or export a new model.
+- **No automatic updates:** Models are downloaded when you ask for them in preferences; nothing happens in the background.
+- **No analytics:** darktable does not report model use, provider selection, or inference performance anywhere.

--- a/content/special-topics/ai/overview.md
+++ b/content/special-topics/ai/overview.md
@@ -1,0 +1,51 @@
+---
+title: overview
+id: ai-overview
+weight: 10
+---
+
+darktable uses machine learning models for a handful of image-processing tasks: interactive object masking, denoising, upscaling, etc. This section explains how those features work end-to-end – what runs where, which models exist, how inference is accelerated, and what the user's choices in the [AI preferences](../../../preferences-settings/ai.md) actually control.
+
+AI features are opt-in. They are off by default in a fresh install and can be toggled with a single preference at any time.
+
+# what the AI features do
+
+## tasks
+
+A _task_ is a capability slot inside darktable – "produce a mask around the clicked subject", "denoise an RGB image", and so on. Tasks are decoupled from the model that implements them: multiple competing models can live on disk for the same task (the NIND denoiser, the NAFNet denoiser, an experimental third…), but only one of them is _active_ for that task at any given time, and that's the one darktable's modules consume. Switching active model is a one-click toggle in [AI preferences](../../../preferences-settings/ai.md) and requires no changes to any module – the consumer just asks for "the active denoise model" and gets whichever you chose.
+
+This indirection is why the model repository can publish alternative or improved models without darktable needing to know about them ahead of time: pick the model in preferences and every consumer of that task picks it up automatically.
+
+darktable currently exposes four tasks:
+
+mask
+: Interactive object segmentation. Click on a subject in the darkroom and the model produces a mask around it. Used by the parametric mask machinery to select regions without drawing by hand. Powered by models such as SAM 2.1 and SegNext.
+
+denoise
+: Machine-learning RGB denoise as an alternative to the classical denoise modules. Operates on already-demosaiced RGB, trained on pairs of noisy and clean images. Removes sensor noise without the blocky or smoothed look that can come from traditional filters.
+
+rawdenoise
+: Machine-learning denoise applied directly to the raw CFA mosaic before demosaic, with denoise and demosaic combined into a single inference pass. Saved out as a LinearRaw DNG and re-imported, so downstream darkroom processing is unchanged. Useful when sensor noise needs to be addressed before the demosaic algorithm runs.
+
+upscale
+: 2x and 4x super-resolution, producing plausible detail from low-resolution inputs. Useful for small or cropped images where classical interpolation would blur.
+
+Tasks run only when a user triggers them – there is no continuous AI activity in the background, no telemetry, and no cloud component. Everything runs locally on your machine.
+
+## a note on accuracy
+
+Like any machine-learning system, the AI features in darktable are not perfect. Every model has edge cases where its output will look worse than the classical alternative – unusual subjects, extreme exposures, or content far from what the model was trained on. This is intrinsic to how ML works, not a bug: 100% accuracy across all possible inputs is not something any model – ours or anyone else's – can offer.
+
+What the models _can_ offer is consistently good results in the common cases they were designed for. The right mindset is to treat AI features as a tool that's usually better than the classical alternative, and to keep the classical modules available as a fallback on the few images where AI output is not. If you find a case where an AI model produces a noticeably poor result, please consider reporting it so the model can be improved over time.
+
+# what darktable does _not_ do
+
+darktable uses _narrow AI_ – small, task-specific models that run on your laptop and do one well-defined job (denoise, mask, upscale). It does **not** use the large generative models that can rewrite photographs – no sky replacement, no inserted objects, no style transfer, no synthesised content of any kind. The full scope is set out in the project's [AI Model Integration Policy](https://github.com/darktable-org/darktable/wiki/AI-Model-Integration-Policy); the governing principle is **scene integrity**: AI may correct technical defects of the capture, but it may not change what was in front of the camera.
+
+Beyond scope, the technical guarantees:
+
+- **No cloud inference.** Every model runs locally on your CPU or GPU. Nothing about your image is sent off-device.
+- **No autonomous edits.** Every AI feature is user-triggered; there's no background AI activity on your library.
+- **No training.** darktable ships pre-trained models and runs inference only. The [darktable-ai](https://github.com/darktable-org/darktable-ai) repository holds the conversion scripts and training notes for anyone who wants to retrain or export a new model.
+- **No automatic updates.** Models are downloaded when you ask for them in preferences; nothing happens in the background.
+- **No analytics.** darktable does not report model use, provider selection, or inference performance anywhere.

--- a/content/special-topics/ai/performance-and-troubleshooting.md
+++ b/content/special-topics/ai/performance-and-troubleshooting.md
@@ -21,6 +21,8 @@ Most AI problems fall into one of three buckets.
 
 Check that AI features are enabled in [AI preferences](../../../preferences-settings/ai.md) – the master toggle is off by default.
 
+If the AI tab itself is missing from preferences, darktable was built without AI support. The official darktable builds (Linux AppImage, Windows installer, macOS dmg) all include it, but third-party packagers may ship a build without it. Ask your distribution's package maintainer to enable AI support, or switch to an official build.
+
 If enabled and the feature is still missing, the required model may not be installed or active. Open AI preferences and confirm a model is ticked in the _enabled_ column for the relevant task. Only one model per task can be active at a time.
 
 ## inference fails or falls back to CPU unexpectedly
@@ -35,7 +37,7 @@ Run darktable from a terminal with `darktable -d ai` to see ONNX Runtime load me
 
 AI denoise and upscale are restoration tasks – the model is inferring plausible output from a training prior. Slight color or contrast shifts are possible, especially for images outside the training distribution (extreme ISO, synthetic captures, very wide-gamut scenes).
 
-If fidelity matters more than aggressive cleanup, stick with the classical [denoise (profiled)](../../../module-reference/processing-modules/denoise-profiled.md) module.
+If fidelity matters more than aggressive cleanup, in e.g. denoising an image, stick with the classical [denoise (profiled)](../../../module-reference/processing-modules/denoise-profiled.md) module.
 
 # further reading
 

--- a/content/special-topics/ai/performance-and-troubleshooting.md
+++ b/content/special-topics/ai/performance-and-troubleshooting.md
@@ -1,0 +1,45 @@
+---
+title: performance & troubleshooting
+id: ai-performance-troubleshooting
+weight: 40
+---
+
+# performance notes
+
+- CPU inference is acceptable for object masks (small one-shot evaluations) but much slower for denoise and upscale. A CUDA / MIGraphX / OpenVINO / DirectML / CoreML runtime is strongly recommended if you use those regularly.
+- Upscale at 4x on a large image is memory-hungry regardless of provider. Tiling is enabled automatically to keep memory in check, at a cost of some extra processing time.
+- Loading ONNX Runtime lazily on first use means the very first AI operation after startup takes an extra moment. This is normal.
+- When switching between execution providers (e.g. auto → CUDA), the new provider's first inference incurs a graph-compilation delay. After that, runtime is steady for the rest of the session.
+- **AMD (MIGraphX) has a multi-minute first-run cost per model.** ROCm/MIGraphX compiles the model graph for your specific GPU the first time it sees it, which can take 1–3 minutes for large models (denoise, upscale); mask models are smaller and compile faster. The compiled graph is cached on disk under `~/.cache/darktable/ai_v*_migraphx_*` and reused across darktable restarts, so subsequent runs of the same model are fast.
+- Model discovery is cached at startup. If you drop a new `.dtmodel` file into the models directory manually while darktable is running, open AI preferences and toggle any control to force a rescan.
+
+# troubleshooting
+
+Most AI problems fall into one of three buckets.
+
+## the feature doesn't appear at all
+
+Check that AI features are enabled in [AI preferences](../../../preferences-settings/ai.md) – the master toggle is off by default.
+
+If enabled and the feature is still missing, the required model may not be installed or active. Open AI preferences and confirm a model is ticked in the _enabled_ column for the relevant task. Only one model per task can be active at a time.
+
+## inference fails or falls back to CPU unexpectedly
+
+Run darktable from a terminal with `darktable -d ai` to see ONNX Runtime load messages and provider probe results. Typical causes:
+
+- **`ort_library_path` points at a missing or corrupt file.** Reset the path in preferences (double-click the label) to fall back to the bundled runtime, or re-run _detect_ after re-installing via the [GPU install scripts](../gpu-acceleration/).
+- **The selected execution provider is missing a system dependency.** cuDNN for CUDA; MIGraphX and rocm-smi-lib for AMD; matching ROCm SONAMEs on Fedora-style distros that rebuild ROCm with their own sonames. The install scripts flag these before download; the `darktable -d ai` log will show the exact `dlopen` error at runtime.
+- **The provider was initialised but failed to compile the model graph.** This sometimes happens on first-generation GPUs with outdated drivers. Update your driver, or fall back to a different provider (e.g. DirectML instead of CUDA on Windows).
+
+## results look off
+
+AI denoise and upscale are restoration tasks – the model is inferring plausible output from a training prior. Slight color or contrast shifts are possible, especially for images outside the training distribution (extreme ISO, synthetic captures, very wide-gamut scenes).
+
+If fidelity matters more than aggressive cleanup, stick with the classical [denoise (profiled)](../../../module-reference/processing-modules/denoise-profiled.md) module.
+
+# further reading
+
+- [AI preferences](../../../preferences-settings/ai.md) – every control on the AI preferences tab.
+- [GPU acceleration](../gpu-acceleration/) – installing a GPU-capable ONNX Runtime (scripts, manual, per-vendor recipes).
+- [darktable-ai](https://github.com/darktable-org/darktable-ai) – the model repository, conversion scripts, and development notes.
+- [ONNX Runtime docs](https://onnxruntime.ai/docs/) – upstream reference for execution providers, troubleshooting, and performance tuning.


### PR DESCRIPTION
Adds user-manual coverage of darktable's AI subsystem (introduced in 5.6) so users can configure it from the manual rather than reading source comments or GitHub READMEs:

- **`content/preferences-settings/ai.md`** – every control on the new AI preferences tab: master toggle, AI acceleration picker, ONNX Runtime library path (with browse + detect), and the model-management table (download / update default, download / update selected, import from file, delete selected).
- **`content/special-topics/ai/overview.md`** – what the AI features do at a high level: tasks vs. models, opt-in, model repository.
- **`content/special-topics/ai/how-ai-works.md`** – under the hood: ONNX Runtime, execution providers, model layout, activation.
- **`content/special-topics/ai/gpu-acceleration.md`** – the two-step process for enabling GPU acceleration (install a GPU-capable ONNX Runtime, point darktable at it). Covers per-vendor requirements, the install scripts (`--ep` flag, prerequisites, one-line install for Linux and Windows), system-installed detection, and full manual-install instructions with per-vendor download targets, the AMD `repo.radeon.com` fallback (with `HIP_VISIBLE_DEVICES` / `HSA_OVERRIDE_GFX_VERSION` workarounds for unsupported `gfx*` IDs), the AMD build-from-source path, and the GitHub API rate-limit caveat for CUDA 13.
- **`content/special-topics/ai/performance-and-troubleshooting.md`** – performance notes (incl. the multi-minute first-run graph-compile cost on AMD MIGraphX, which catches users by surprise) and a troubleshooting walk-through keyed on `darktable -d ai` output.