### PR TITLE
rename drawn masks for visibility of AI masks

### DIFF
--- a/content/darkroom/masking-and-blending/masks/drawn.md
+++ b/content/darkroom/masking-and-blending/masks/drawn.md
@@ -1,5 +1,5 @@
 ---
-title: drawn masks
+title: drawn masks & AI masking
 id: drawn
 weight: 20
 ---


### PR DESCRIPTION
Going through the docs I noticed that with the current setup AI masks are kinda hidden and can't be easily discovered though the search function. So I suggest renaming the "drawn masks" to "drawn masks & AI masking". An alternative could be to remove the AI masks from the drawn masks and give them their own page within the masking section. 