### PR TITLE
Fix link to doc pending PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The user manual for the current stable release of darktable can be found at [dar
 
 Please see https://darktable-org.github.io/dtdocs/en/contributing for information about contributing content
 
-For a complete list of the outstanding work please see the [issues](https://github.com/darktable-org/dtdocs/issues) in this repository and a list of [undocumented pull requests](https://github.com/darktable-org/darktable/pulls?q=is%3Apr+label%3Adocumentation-pending+is%3Aclosed) in the darktable repository.
+For a complete list of the outstanding work please see the [issues](https://github.com/darktable-org/dtdocs/issues) in this repository and a list of [undocumented pull requests](https://github.com/darktable-org/darktable/pulls?q=is%3Apr+is%3Aclosed+label%3A%22documentation:%20pending%22) in the darktable repository.
 
 ## Obtaining and Building
 

--- a/content/contributing/overview.md
+++ b/content/contributing/overview.md
@@ -24,7 +24,7 @@ We are generally **not** interested in:
 We **are** interested in
 1. Spelling and grammar corrections
 1. Clarification of text
-1. [Documentation for new features](https://github.com/darktable-org/darktable/pulls?q=is%3Apr+is%3Aclosed+label%3Adocumentation-pending+)
+1. [Documentation for new features](https://github.com/darktable-org/darktable/pulls?q=is%3Apr+is%3Aclosed+label%3A%22documentation:%20pending%22)
 
 We are always extremely interested in hearing about which sections of the manual did not make sense to you and *why*, so that we can improve the documentation.
 


### PR DESCRIPTION
A couple of instances of the link for pending documentation PRs being broken (perhaps the label name changed).
