### PR TITLE
Fix AI mask link, add 4x upscale note and clarify scale factor

### DIFF
--- a/content/darkroom/masking-and-blending/masks/ai-masking.md
+++ b/content/darkroom/masking-and-blending/masks/ai-masking.md
@@ -9,4 +9,4 @@ AI masking requires AI features to be enabled in [AI preferences](../../../prefe
 Currently darktable provides one AI masking tool:
 
 AI object
-: Uses the _mask_ task. Click on a subject to produce a mask around it; iterate by adding more clicks until it covers exactly what you want. The result is vectorised into a group of path shapes and can be edited like any other drawn shape – see [drawn masks: object](../drawn#object) for details.
+: Uses the _mask_ task. Click on a subject to produce a mask around it; iterate by adding more clicks until it covers exactly what you want. The result is vectorised into a group of path shapes and can be edited like any other drawn shape – see [drawn masks: AI object](../drawn/#available-shapes) for details.

--- a/content/module-reference/utility-modules/shared/neural-restore.md
+++ b/content/module-reference/utility-modules/shared/neural-restore.md
@@ -42,7 +42,9 @@ denoise
 upscale
 : Super-resolution to 2x or 4x the input pixel dimensions. Writes a TIFF at the upscaled size. 4x on a high-resolution image is memory-hungry; tile processing is enabled automatically to keep peak memory bounded, at the cost of some extra processing time.
 
-: - _scale_ – output magnification factor (_2x_ or _4x_). Larger factors are slower and need more GPU memory.
+: - _scale_ – output magnification factor applied to each side of the image (_2x_ or _4x_). _2x_ doubles the width and height, producing four times as many pixels overall; _4x_ quadruples each side, producing sixteen times as many. Larger factors are slower and need more GPU memory.
+
+: **Note:** 4x upscaling is significantly more demanding on the model than 2x, since it must invent 16x as many pixels of new detail as the original. Fine textures and high-frequency content may be less convincing than at 2x – use 2x when it meets your resolution requirements.
 
 # where the tasks sit in your workflow
 


### PR DESCRIPTION
Two small AI-doc fixes:

- **`ai-masking.md`** – the link to the drawn-shapes section was pointing at the old anchor `../drawn#object`; updated to `../drawn/#available-shapes`.

- **`neural-restore.md`** – clarified that the upscale _scale_ factor is per-side (so _4x_ produces 16x the pixels, not 4x), and added a note that 4x upscaling is meaningfully harder for the model than 2x and may give softer fine textures – worth steering users toward 2x when it covers their output needs.