### PR TITLE
Add the individual processing module tooltip information

### DIFF
--- a/content/module-reference/overview.md
+++ b/content/module-reference/overview.md
@@ -9,7 +9,7 @@ The modules in this reference section are broken down into two distinct types:
 [processing modules](./processing-modules/_index.md)
 : Processing modules are used exclusively in the darkroom view. Each module performs a processing operation on the image before passing its output to the next module for further processing. Together this sequence of processing steps forms the [pixelpipe](../darkroom/pixelpipe/the-pixelpipe-and-module-order.md).
 
-  Processing modules have a _Synopsis_ section which gives:
+  Processing modules have a _Synopsis_ section which gives a brief summary of the module (the information can also be seen as a tooltip when hovering over the module name). The following information is shown:
     * a brief outline of the purpose of the module
     * an indication of the purpose (e.g. corrective or creative)
     * the processing color space (e.g. non-linear, Lab)

--- a/content/module-reference/overview.md
+++ b/content/module-reference/overview.md
@@ -9,6 +9,14 @@ The modules in this reference section are broken down into two distinct types:
 [processing modules](./processing-modules/_index.md)
 : Processing modules are used exclusively in the darkroom view. Each module performs a processing operation on the image before passing its output to the next module for further processing. Together this sequence of processing steps forms the [pixelpipe](../darkroom/pixelpipe/the-pixelpipe-and-module-order.md).
 
+  Processing modules have a _Synopsis_ section which gives:
+    * a brief outline of the purpose of the module
+    * an indication of the purpose (e.g. corrective or creative)
+    * the processing color space (e.g. non-linear, Lab)
+    * information about input and output:
+      * color space (e.g. linear, RGB)
+      * display referred or [scene referred workflow](../overview/workflow/process.md#scene-referred-workflow-a-new-approach)
+
 [utility modules](./utility-modules/_index.md)
 : Utility modules may be used in any darktable view. They are not directly involved in processing the pixels of an image but perform other ancillary functions (managing image metadata and tags, editing history, modifying pixel pipeline order, snapshots and duplicates, image export etc.).
 

--- a/content/module-reference/overview.md
+++ b/content/module-reference/overview.md
@@ -9,7 +9,7 @@ The modules in this reference section are broken down into two distinct types:
 [processing modules](./processing-modules/_index.md)
 : Processing modules are used exclusively in the darkroom view. Each module performs a processing operation on the image before passing its output to the next module for further processing. Together this sequence of processing steps forms the [pixelpipe](../darkroom/pixelpipe/the-pixelpipe-and-module-order.md).
 
-  Processing modules have a _Synopsis_ section which gives a brief summary of the module (the information can also be seen as a tooltip when hovering over the module name). The following information is shown:
+  Processing modules have a _Technical information_ section which gives a brief summary of the module (the information can also be seen as a tooltip when hovering over the module name). The following information is shown:
     * a brief outline of the purpose of the module
     * an indication of the purpose (e.g. corrective or creative)
     * the processing color space (e.g. non-linear, Lab)

--- a/content/module-reference/processing-modules/agx.md
+++ b/content/module-reference/processing-modules/agx.md
@@ -4,7 +4,7 @@ id: agx
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : applies a tone mapping curve. inspired by Blender's AgX tone mapper.
 

--- a/content/module-reference/processing-modules/agx.md
+++ b/content/module-reference/processing-modules/agx.md
@@ -4,6 +4,23 @@ id: agx
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: applies a tone mapping curve. inspired by Blender's AgX tone mapper.
+
+purpose
+: corrective and creative.
+
+input
+: linear, RGB, scene-referred.
+
+processing
+: non-linear, RGB.
+
+output
+: linear, RGB, display-referred
+{{< /details >}}
+
 Transform the colors and tonal range of an image to fit a display.
 
 The primary innovation of the AgX module is an advanced color handling method that ensures a natural and film-like appearance, preventing the oversaturation artifacts common with simpler tone mapping techniques. It is derived from the display transform of the same name, used in the [Blender 3D modeler](https://www.blender.org/) by T. J. Sobotka, Eary_Chow, Sakari Kapanen and others.

--- a/content/module-reference/processing-modules/astrophoto-denoise.md
+++ b/content/module-reference/processing-modules/astrophoto-denoise.md
@@ -4,6 +4,23 @@ id: astrophoto-denoise
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: apply a poisson noise removal best suited for astrophotography.
+
+purpose
+: corrective.
+
+input
+: non-linear, Lab, display-referred.
+
+processing
+: non-linear, Lab.
+
+output
+: non-linear, Lab, display-referred
+{{< /details >}}
+
 Remove image noise while preserving structure. 
 
 This is accomplished by averaging each pixel with some surrounding pixels in the image. The weight of such a pixel in the averaging process depends on the similarity of its neighborhood with the neighborhood of the pixel being denoised. A patch with a defined size is used to measure that similarity. 

--- a/content/module-reference/processing-modules/astrophoto-denoise.md
+++ b/content/module-reference/processing-modules/astrophoto-denoise.md
@@ -4,7 +4,7 @@ id: astrophoto-denoise
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : apply a poisson noise removal best suited for astrophotography.
 

--- a/content/module-reference/processing-modules/base-curve.md
+++ b/content/module-reference/processing-modules/base-curve.md
@@ -4,6 +4,23 @@ id: base-curve
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: apply a view transform based on personal or camera maker look, for corrective purposes, to prepare images for display.
+
+purpose
+: corrective.
+
+input
+: linear, RGB, display-referred.
+
+processing
+: non-linear, RGB.
+
+output
+: non-linear, RGB, display-referred
+{{< /details >}}
+
 Simulate the in-camera JPEG by applying a characteristic base curve to the image.
 
 darktable comes with a number of base curve presets that attempt to mimic the curves of various camera manufacturers. These presets are automatically applied according to the "maker ID" found in the image's Exif data. Camera-specific base curve presets are also available for some camera models. 

--- a/content/module-reference/processing-modules/base-curve.md
+++ b/content/module-reference/processing-modules/base-curve.md
@@ -4,7 +4,7 @@ id: base-curve
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : apply a view transform based on personal or camera maker look, for corrective purposes, to prepare images for display.
 

--- a/content/module-reference/processing-modules/basic-adjustments.md
+++ b/content/module-reference/processing-modules/basic-adjustments.md
@@ -6,6 +6,23 @@ weight: 20
 
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: apply usual image adjustments.
+
+purpose
+: creative.
+
+input
+: linear, RGB, scene-referred.
+
+processing
+: non-linear, RGB.
+
+output
+: non-linear, RGB, scene-referred
+{{< /details >}}
+
 **Please note that this module is [deprecated](../../darkroom/processing-modules/deprecated.md) from darktable 3.6 and should no longer be used for new edits. Please use the [quick access panel](../../darkroom/organization/quick-access-panel.md) instead.**
 
 ---

--- a/content/module-reference/processing-modules/basic-adjustments.md
+++ b/content/module-reference/processing-modules/basic-adjustments.md
@@ -6,7 +6,7 @@ weight: 20
 
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : apply usual image adjustments.
 

--- a/content/module-reference/processing-modules/bloom.md
+++ b/content/module-reference/processing-modules/bloom.md
@@ -4,6 +4,23 @@ id: bloom
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: apply Orton effect for a dreamy ethereal look.
+
+purpose
+: creative.
+
+input
+: non-linear, Lab, display-referred.
+
+processing
+: non-linear, Lab.
+
+output
+: non-linear, Lab, display-referred
+{{< /details >}}
+
 Create a soft bloom effect. 
 
 This module works by blurring the highlights and then blending the result with the original image.

--- a/content/module-reference/processing-modules/bloom.md
+++ b/content/module-reference/processing-modules/bloom.md
@@ -4,7 +4,7 @@ id: bloom
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : apply Orton effect for a dreamy ethereal look.
 

--- a/content/module-reference/processing-modules/blurs.md
+++ b/content/module-reference/processing-modules/blurs.md
@@ -4,6 +4,23 @@ id: blurs
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: simulate physically-accurate lens and motion blurs.
+
+purpose
+: creative.
+
+input
+: linear, RGB, scene-referred.
+
+processing
+: linear, RGB.
+
+output
+: linear, RGB, scene-referred
+{{< /details >}}
+
 Simulate physically-accurate blurs in scene-referred RGB space.
 
 # blur types

--- a/content/module-reference/processing-modules/blurs.md
+++ b/content/module-reference/processing-modules/blurs.md
@@ -4,7 +4,7 @@ id: blurs
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : simulate physically-accurate lens and motion blurs.
 

--- a/content/module-reference/processing-modules/censorize.md
+++ b/content/module-reference/processing-modules/censorize.md
@@ -4,6 +4,23 @@ id: censorize
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: censorize license plates and body parts for privacy.
+
+purpose
+: creative.
+
+input
+: linear or non-linear, RGB, scene-referred.
+
+processing
+: frequential, RGB.
+
+output
+: special, RGB, scene-referred
+{{< /details >}}
+
 Degrade parts of the image in an aesthetically pleasing way, in order to anonymize people/objects or hide body parts.
 
 Censorize works in linear RGB color space to apply a physically-accurate gaussian blur and gaussian luminance noise.

--- a/content/module-reference/processing-modules/censorize.md
+++ b/content/module-reference/processing-modules/censorize.md
@@ -4,7 +4,7 @@ id: censorize
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : censorize license plates and body parts for privacy.
 

--- a/content/module-reference/processing-modules/channel-mixer.md
+++ b/content/module-reference/processing-modules/channel-mixer.md
@@ -6,6 +6,23 @@ weight: 20
 
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: perform color space corrections such as white balance, channels mixing and conversions to monochrome emulating film.
+
+purpose
+: corrective or creative.
+
+input
+: linear, RGB, display-referred.
+
+processing
+: linear, RGB.
+
+output
+: linear, RGB, display-referred
+{{< /details >}}
+
 **Please note that this module is [deprecated](../../darkroom/processing-modules/deprecated.md) from darktable 3.4 and should no longer be used for new edits. Please use the [_color calibration_](./color-calibration.md) module instead.**
 
 ---

--- a/content/module-reference/processing-modules/channel-mixer.md
+++ b/content/module-reference/processing-modules/channel-mixer.md
@@ -6,7 +6,7 @@ weight: 20
 
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : perform color space corrections such as white balance, channels mixing and conversions to monochrome emulating film.
 

--- a/content/module-reference/processing-modules/chromatic-aberrations.md
+++ b/content/module-reference/processing-modules/chromatic-aberrations.md
@@ -4,6 +4,23 @@ id: chromatic-aberrations
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: correct chromatic aberrations.
+
+purpose
+: corrective.
+
+input
+: linear, RGB, scene-referred.
+
+processing
+: linear, RGB.
+
+output
+: linear, RGB, scene-referred
+{{< /details >}}
+
 Correct chromatic aberrations.
 
 In contrast to the [_raw chromatic aberrations_](./raw-chromatic-aberrations.md) module, this module does not require raw data as input.

--- a/content/module-reference/processing-modules/chromatic-aberrations.md
+++ b/content/module-reference/processing-modules/chromatic-aberrations.md
@@ -4,7 +4,7 @@ id: chromatic-aberrations
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : correct chromatic aberrations.
 

--- a/content/module-reference/processing-modules/color-balance-rgb.md
+++ b/content/module-reference/processing-modules/color-balance-rgb.md
@@ -4,6 +4,23 @@ id: color-balance
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: color grading tools using alpha masks to separate shadows, mid-tones and highlights.
+
+purpose
+: corrective or creative.
+
+input
+: linear, RGB, scene-referred.
+
+processing
+: non-linear, RGB.
+
+output
+: non-linear, RGB, scene-referred
+{{< /details >}}
+
 An advanced module which brings color-grading tools from cinematography into the photographic scene-referred pipeline.
 
 This module is not suitable for beginners with no prior knowledge of color theory, who might want to stick to the _global chroma_ and _global vibrance_ settings until they have a good understanding of the [dimensions of color](../../special-topics/color-management/color-dimensions.md).

--- a/content/module-reference/processing-modules/color-balance-rgb.md
+++ b/content/module-reference/processing-modules/color-balance-rgb.md
@@ -4,7 +4,7 @@ id: color-balance
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : color grading tools using alpha masks to separate shadows, mid-tones and highlights.
 

--- a/content/module-reference/processing-modules/color-balance.md
+++ b/content/module-reference/processing-modules/color-balance.md
@@ -4,7 +4,7 @@ id: color-balance
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : shift colors selectively by luminance range.
 

--- a/content/module-reference/processing-modules/color-balance.md
+++ b/content/module-reference/processing-modules/color-balance.md
@@ -4,6 +4,23 @@ id: color-balance
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: shift colors selectively by luminance range.
+
+purpose
+: corrective or creative.
+
+input
+: linear, Lab, scene-referred.
+
+processing
+: non-linear, RGB.
+
+output
+: non-linear, Lab, scene-referred
+{{< /details >}}
+
 A versatile tool for adjusting the image's color balance. 
 
 This module can be used to revert parasitic color casts or to enhance the visual atmosphere of an image using color grading, a popular technique in the cinema industry. For scene-referred workflow, you should consider using the improved [_color balance rgb_](./color-balance-rgb.md) module instead.

--- a/content/module-reference/processing-modules/color-calibration.md
+++ b/content/module-reference/processing-modules/color-calibration.md
@@ -5,7 +5,7 @@ weight: 10
 include_toc: true
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : perform color space corrections such as white balance, channels mixing and conversions to monochrome emulating film.
 

--- a/content/module-reference/processing-modules/color-calibration.md
+++ b/content/module-reference/processing-modules/color-calibration.md
@@ -5,6 +5,23 @@ weight: 10
 include_toc: true
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: perform color space corrections such as white balance, channels mixing and conversions to monochrome emulating film.
+
+purpose
+: corrective or creative.
+
+input
+: linear, RGB, scene-referred.
+
+processing
+: linear, RGB or XYZ.
+
+output
+: linear, RGB, scene-referred
+{{< /details >}}
+
 A fully-featured color-space correction, white balance adjustment and channel mixer module.
 
 This simple yet powerful module can be used in the following ways:

--- a/content/module-reference/processing-modules/color-contrast.md
+++ b/content/module-reference/processing-modules/color-contrast.md
@@ -4,7 +4,7 @@ id: color-contrast
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : increase saturation and separation between opposite colors.
 

--- a/content/module-reference/processing-modules/color-contrast.md
+++ b/content/module-reference/processing-modules/color-contrast.md
@@ -4,6 +4,23 @@ id: color-contrast
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: increase saturation and separation between opposite colors.
+
+purpose
+: creative.
+
+input
+: non-linear, Lab, display-referred.
+
+processing
+: non-linear, Lab.
+
+output
+: non-linear, Lab, display-referred
+{{< /details >}}
+
 A simplified control for changing the contrast or separation of colors between the green/magenta and blue/yellow axes in Lab color space. Higher values increase color contrast, lower values decrease it.
 
 # module controls

--- a/content/module-reference/processing-modules/color-correction.md
+++ b/content/module-reference/processing-modules/color-correction.md
@@ -4,6 +4,23 @@ id: color-correction
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: correct white balance selectively for blacks and whites.
+
+purpose
+: corrective or creative.
+
+input
+: non-linear, Lab, display-referred.
+
+processing
+: non-linear, Lab.
+
+output
+: non-linear, Lab, display-referred
+{{< /details >}}
+
 Modify the global image saturation to give the image a tint or as an alternative method to split-tone the image.
 
 ---

--- a/content/module-reference/processing-modules/color-correction.md
+++ b/content/module-reference/processing-modules/color-correction.md
@@ -4,7 +4,7 @@ id: color-correction
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : correct white balance selectively for blacks and whites.
 

--- a/content/module-reference/processing-modules/color-equalizer.md
+++ b/content/module-reference/processing-modules/color-equalizer.md
@@ -4,7 +4,7 @@ id: color-equalizer
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : change saturation, hue and brightness depending on local hue.
 

--- a/content/module-reference/processing-modules/color-equalizer.md
+++ b/content/module-reference/processing-modules/color-equalizer.md
@@ -4,6 +4,23 @@ id: color-equalizer
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: change saturation, hue and brightness depending on local hue.
+
+purpose
+: corrective and creative.
+
+input
+: linear, RGB, scene-referred.
+
+processing
+: quasi-linear, RGB.
+
+output
+: quasi-linear, RGB, scene-referred
+{{< /details >}}
+
 Selectively adjust the hue, saturation, and/or brightness of pixels based on their current hue.
 
 This module is an attempt to recreate _some_ of the functionality of the [_color zones_](./color-zones.md) module in the [scene-referred](../../special-topics/color-pipeline.md) part of the pipeline whilst overcoming some of that module's limitations. Specifically, the _color zones_ module is prone to increase chroma/luma noise, and introduce artifacts or harsh transitions. These are somewhat mitigated within _color equalizer_ with the following additions:

--- a/content/module-reference/processing-modules/color-harmonizer.md
+++ b/content/module-reference/processing-modules/color-harmonizer.md
@@ -4,6 +4,23 @@ id: color-harmonizer
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: harmonize colors toward a selected palette in perceptual space.
+
+purpose
+: creative color grading.
+
+input
+: linear, RGB, scene-referred.
+
+processing
+: darktable UCS / JCH (perceptual).
+
+output
+: linear, RGB, scene-referred
+{{< /details >}}
+
 The color harmonizer reduces chromatic dissonance by pushing hues toward a selected color palette.
 This palette is defined by a set of hue angles called harmony nodes.
 Colors that are "off-palette" are gently pulled toward the nearest node; colors already on a node are left unchanged.

--- a/content/module-reference/processing-modules/color-harmonizer.md
+++ b/content/module-reference/processing-modules/color-harmonizer.md
@@ -4,7 +4,7 @@ id: color-harmonizer
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : harmonize colors toward a selected palette in perceptual space.
 

--- a/content/module-reference/processing-modules/color-look-up-table.md
+++ b/content/module-reference/processing-modules/color-look-up-table.md
@@ -4,6 +4,23 @@ id: color-look-up-table
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: perform color space corrections and apply looks.
+
+purpose
+: corrective or creative.
+
+input
+: linear or non-linear, Lab, display-referred.
+
+processing
+: defined by profile, Lab.
+
+output
+: linear or non-linear, Lab, display-referred
+{{< /details >}}
+
 A generic color look up table implemented in Lab space. 
 
 The input to this module is a list of source and target points and the complete mapping is interpolated using splines. The resulting look up tables (LUTs) are editable by hand and can be created using the darktable-chart utility to match given input (such as hald-cluts and RAW/JPEG with in-camera processing pairs). See [using darktable-chart](../../special-topics/darktable-chart/_index.md) for details.

--- a/content/module-reference/processing-modules/color-look-up-table.md
+++ b/content/module-reference/processing-modules/color-look-up-table.md
@@ -4,7 +4,7 @@ id: color-look-up-table
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : perform color space corrections and apply looks.
 

--- a/content/module-reference/processing-modules/color-mapping.md
+++ b/content/module-reference/processing-modules/color-mapping.md
@@ -4,6 +4,23 @@ id: color-mapping
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: transfer a color palette and tonal repartition from one image to another.
+
+purpose
+: creative.
+
+input
+: linear or non-linear, Lab, display-referred.
+
+processing
+: non-linear, Lab.
+
+output
+: non-linear, Lab, display-referred
+{{< /details >}}
+
 Transfer the look and feel of one image to another. 
 
 This module statistically analyses the color characteristics of a source and target image. The colors of the source image are then mapped to corresponding colors on the target image.

--- a/content/module-reference/processing-modules/color-mapping.md
+++ b/content/module-reference/processing-modules/color-mapping.md
@@ -4,7 +4,7 @@ id: color-mapping
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : transfer a color palette and tonal repartition from one image to another.
 

--- a/content/module-reference/processing-modules/color-reconstruction.md
+++ b/content/module-reference/processing-modules/color-reconstruction.md
@@ -4,7 +4,7 @@ id: color-reconstruction
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : recover clipped highlights by propagating surrounding colors.
 

--- a/content/module-reference/processing-modules/color-reconstruction.md
+++ b/content/module-reference/processing-modules/color-reconstruction.md
@@ -4,6 +4,23 @@ id: color-reconstruction
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: recover clipped highlights by propagating surrounding colors.
+
+purpose
+: corrective.
+
+input
+: linear or non-linear, Lab, display-referred.
+
+processing
+: non-linear, Lab.
+
+output
+: non-linear, Lab, display-referred
+{{< /details >}}
+
 Recover color information in blown-out highlights.
 
 Due to the nature of digital sensors, overexposed highlights lack valid color information. Most frequently they appear neutral white or exhibit some color cast, depending on what other image processing steps are involved. This module can be used to “heal” overexposed highlights by replacing their colors with better fitting ones. The module acts on pixels whose luminance exceeds a user-defined threshold. Replacement colors are taken from neighboring pixels. Both the spatial distance and the luminance distance (range) are taken into account for color selection.

--- a/content/module-reference/processing-modules/color-zones.md
+++ b/content/module-reference/processing-modules/color-zones.md
@@ -4,6 +4,23 @@ id: color-zones
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: selectively shift hues, chroma and lightness of pixels.
+
+purpose
+: creative.
+
+input
+: linear or non-linear, Lab, display-referred.
+
+processing
+: non-linear, Lab.
+
+output
+: non-linear, Lab, display-referred
+{{< /details >}}
+
 Selectively adjust the lightness, chroma and hue of pixels based on their current lightness, chroma and hue.
 
 This module works in CIE LCh color space, which separates pixels into _lightness_, chroma and _hue_ components. It allows you to manipulate the lightness, chroma and hue of targeted groups of pixels through the use of [curves](../../darkroom/processing-modules/curves.md).

--- a/content/module-reference/processing-modules/color-zones.md
+++ b/content/module-reference/processing-modules/color-zones.md
@@ -4,7 +4,7 @@ id: color-zones
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : selectively shift hues, chroma and lightness of pixels.
 

--- a/content/module-reference/processing-modules/colorize.md
+++ b/content/module-reference/processing-modules/colorize.md
@@ -4,6 +4,23 @@ id: colorize
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: overlay a solid color on the image.
+
+purpose
+: creative.
+
+input
+: linear or non-linear, Lab, display-referred.
+
+processing
+: non-linear, Lab.
+
+output
+: non-linear, Lab, display-referred
+{{< /details >}}
+
 Add a solid layer of color to the image.
 
 # module controls

--- a/content/module-reference/processing-modules/colorize.md
+++ b/content/module-reference/processing-modules/colorize.md
@@ -4,7 +4,7 @@ id: colorize
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : overlay a solid color on the image.
 

--- a/content/module-reference/processing-modules/composite.md
+++ b/content/module-reference/processing-modules/composite.md
@@ -4,7 +4,7 @@ id: composite
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : combine the image with elements from another processed image (move this module to after output color profile if you see banding).
 

--- a/content/module-reference/processing-modules/composite.md
+++ b/content/module-reference/processing-modules/composite.md
@@ -4,6 +4,23 @@ id: composite
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: combine the image with elements from another processed image (move this module to after output color profile if you see banding).
+
+purpose
+: corrective and creative.
+
+input
+: linear, RGB, scene-referred.
+
+processing
+: linear, RGB.
+
+output
+: linear, RGB, scene-referred
+{{< /details >}}
+
 Create a composite image by overlaying an already-processed image on top of the current image.
 
 Drag and drop a processed image from the filmstrip onto the "drop image from filmstrip here" box to overlay the chosen image, and then alter the various placement and adjustment attributes of the image being overlaid.

--- a/content/module-reference/processing-modules/contrast-brightness-saturation.md
+++ b/content/module-reference/processing-modules/contrast-brightness-saturation.md
@@ -6,7 +6,7 @@ weight: 20
 
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : adjust the look of the image.
 

--- a/content/module-reference/processing-modules/contrast-brightness-saturation.md
+++ b/content/module-reference/processing-modules/contrast-brightness-saturation.md
@@ -6,6 +6,23 @@ weight: 20
 
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: adjust the look of the image.
+
+purpose
+: creative.
+
+input
+: non-linear, Lab, display-referred.
+
+processing
+: non-linear, Lab.
+
+output
+: non-linear, Lab, display-referred
+{{< /details >}}
+
 **Please note that this module is [deprecated](../../darkroom/processing-modules/deprecated.md) from darktable 4.4 and should no longer be used for new edits. Please use the [_color balance rgb_](./color-balance-rgb.md) module instead.**
 
 ---

--- a/content/module-reference/processing-modules/contrast-equalizer.md
+++ b/content/module-reference/processing-modules/contrast-equalizer.md
@@ -4,6 +4,23 @@ id: contrast-equalizer
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: add or remove local contrast, sharpness, acutance.
+
+purpose
+: corrective and creative.
+
+input
+: linear, Lab, scene-referred.
+
+processing
+: frequential, RGB.
+
+output
+: linear, Lab, scene-referred
+{{< /details >}}
+
 Adjust luminance and chroma contrast in the wavelet domain.
 
 This versatile module can be used to achieve a variety of effects, including bloom, denoise, clarity, and local contrast enhancement. 

--- a/content/module-reference/processing-modules/contrast-equalizer.md
+++ b/content/module-reference/processing-modules/contrast-equalizer.md
@@ -4,7 +4,7 @@ id: contrast-equalizer
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : add or remove local contrast, sharpness, acutance.
 

--- a/content/module-reference/processing-modules/crop-rotate.md
+++ b/content/module-reference/processing-modules/crop-rotate.md
@@ -6,7 +6,7 @@ weight: 20
 
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : change the framing and correct the perspective.
 

--- a/content/module-reference/processing-modules/crop-rotate.md
+++ b/content/module-reference/processing-modules/crop-rotate.md
@@ -6,6 +6,23 @@ weight: 20
 
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: change the framing and correct the perspective.
+
+purpose
+: corrective or creative.
+
+input
+: linear, RGB, scene-referred.
+
+processing
+: geometric, RGB.
+
+output
+: linear, RGB, scene-referred
+{{< /details >}}
+
 **Please note that this module is [deprecated](../../darkroom/processing-modules/deprecated.md) from darktable 3.8 and should no longer be used for new edits. Please use the [_crop_](./crop.md) module to crop the image, the [_rotate and perspective_](./rotate-perspective.md) module to perform rotation and keystone correction, and the [_orientation_](./orientation.md) module to flip the image on the horizontal/vertical axes.**
 
 ---

--- a/content/module-reference/processing-modules/crop.md
+++ b/content/module-reference/processing-modules/crop.md
@@ -4,6 +4,23 @@ id: crop
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: change the framing.
+
+purpose
+: corrective or creative.
+
+input
+: linear, RGB, scene-referred.
+
+processing
+: geometric, RGB.
+
+output
+: linear, RGB, scene-referred
+{{< /details >}}
+
 Crop an image using on-screen guides.
 
 This module appears later in the pipeline than the deprecated [_crop and rotate_](./crop-rotate.md) module, meaning that the full image can remain available for source spots in the [_retouch_](./retouch.md) module. For best results, you are advised to use the [_rotate and perspective_](./rotate-perspective.md) module to perform rotation and perspective correction (if required), and then perform final creative cropping with this module.

--- a/content/module-reference/processing-modules/crop.md
+++ b/content/module-reference/processing-modules/crop.md
@@ -4,7 +4,7 @@ id: crop
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : change the framing.
 

--- a/content/module-reference/processing-modules/defringe.md
+++ b/content/module-reference/processing-modules/defringe.md
@@ -6,7 +6,7 @@ weight: 20
 
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : attenuate chromatic aberration by desaturating edges.
 

--- a/content/module-reference/processing-modules/defringe.md
+++ b/content/module-reference/processing-modules/defringe.md
@@ -6,6 +6,23 @@ weight: 20
 
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: attenuate chromatic aberration by desaturating edges.
+
+purpose
+: corrective.
+
+input
+: linear or non-linear, Lab, display-referred.
+
+processing
+: non-linear, Lab.
+
+output
+: non-linear, Lab, display-referred
+{{< /details >}}
+
 **Please note that this module is [deprecated](../../darkroom/processing-modules/deprecated.md) from darktable 3.6 and should no longer be used for new edits. Please use the [_chromatic aberrations_](./chromatic-aberrations.md) module instead.**
 
 ---

--- a/content/module-reference/processing-modules/demosaic.md
+++ b/content/module-reference/processing-modules/demosaic.md
@@ -4,6 +4,23 @@ id: demosaic
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: reconstruct full RGB pixels from a sensor color filter array reading.
+
+purpose
+: mandatory.
+
+input
+: linear, raw, scene-referred.
+
+processing
+: linear, raw.
+
+output
+: linear, RGB, scene-referred
+{{< /details >}}
+
 Control how raw files are demosaiced and optionally apply capture sharpening.
 
 # bayer filters

--- a/content/module-reference/processing-modules/demosaic.md
+++ b/content/module-reference/processing-modules/demosaic.md
@@ -4,7 +4,7 @@ id: demosaic
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : reconstruct full RGB pixels from a sensor color filter array reading.
 

--- a/content/module-reference/processing-modules/denoise-profiled.md
+++ b/content/module-reference/processing-modules/denoise-profiled.md
@@ -4,7 +4,7 @@ id: denoise-profiled
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : denoise using noise statistics profiled on sensors.
 

--- a/content/module-reference/processing-modules/denoise-profiled.md
+++ b/content/module-reference/processing-modules/denoise-profiled.md
@@ -4,6 +4,23 @@ id: denoise-profiled
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: denoise using noise statistics profiled on sensors.
+
+purpose
+: corrective.
+
+input
+: linear, RGB, scene-referred.
+
+processing
+: linear, RGB.
+
+output
+: linear, RGB, scene-referred
+{{< /details >}}
+
 An easy to use and highly efficient denoise module, adapted to the individual noise profiles of a wide range of camera sensors.
 
 One issue with a lot of denoising algorithms is that they assume that the variance of the noise is independent of the luminosity of the signal. By profiling the noise characteristics of a camera's sensor at different ISO settings, the variance at different luminosities can be assessed, and the denoising algorithm can be adjusted to more evenly smooth out the noise.

--- a/content/module-reference/processing-modules/diffuse.md
+++ b/content/module-reference/processing-modules/diffuse.md
@@ -4,7 +4,7 @@ id: diffuse
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : simulate directional diffusion of light with heat transfer model to apply an iterative edge-oriented blur, inpaint damaged parts of the image, or to remove blur with blind deconvolution.
 

--- a/content/module-reference/processing-modules/diffuse.md
+++ b/content/module-reference/processing-modules/diffuse.md
@@ -4,6 +4,23 @@ id: diffuse
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: simulate directional diffusion of light with heat transfer model to apply an iterative edge-oriented blur, inpaint damaged parts of the image, or to remove blur with blind deconvolution.
+
+purpose
+: corrective and creative.
+
+input
+: linear, RGB, scene-referred.
+
+processing
+: linear, RGB.
+
+output
+: linear, RGB, scene-referred
+{{< /details >}}
+
 Diffusion is a family of physical processes by which particles move and spread gradually with time, from a source that generates them. In image processing, diffusion mostly occurs in two places:
 
 - diffusion of photons through lens glass (blur) or humid air (hazing),

--- a/content/module-reference/processing-modules/dither-or-posterize.md
+++ b/content/module-reference/processing-modules/dither-or-posterize.md
@@ -4,7 +4,7 @@ id: dither-or-posterize
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : reduce banding and posterization effects in output JPEGs by adding random noise, or reduce bit depth.
 

--- a/content/module-reference/processing-modules/dither-or-posterize.md
+++ b/content/module-reference/processing-modules/dither-or-posterize.md
@@ -4,6 +4,23 @@ id: dither-or-posterize
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: reduce banding and posterization effects in output JPEGs by adding random noise, or reduce bit depth.
+
+purpose
+: corrective, artistic.
+
+input
+: non-linear, RGB, display-referred.
+
+processing
+: non-linear, RGB.
+
+output
+: non-linear, RGB, display-referred
+{{< /details >}}
+
 This module eliminates some of the banding artifacts that can result when darktable's internal 32-bit floating point data is transferred into discrete 8-bit or 16-bit integer output format for display or export. It can also be used for creative posterization effects.
 
 Although not an inherent problem in any of darktable's modules, some operations may provoke banding if they produce a lightness gradient in the image. To mitigate possible artifacts you should consider activating dithering when using the [_vignetting_](./vignetting.md) or [_graduated density_](./graduated-density.md) modules. This is especially relevant for images with extended homogeneous areas such as cloudless sky. Also watch out for banding artifacts when using a gradient [drawn mask](../../darkroom/masking-and-blending/masks/drawn).

--- a/content/module-reference/processing-modules/enlarge-canvas.md
+++ b/content/module-reference/processing-modules/enlarge-canvas.md
@@ -4,7 +4,7 @@ id: enlarge-canvas
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : add empty space to the left, top, right or bottom.
 

--- a/content/module-reference/processing-modules/enlarge-canvas.md
+++ b/content/module-reference/processing-modules/enlarge-canvas.md
@@ -4,6 +4,23 @@ id: enlarge-canvas
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: add empty space to the left, top, right or bottom.
+
+purpose
+: corrective and creative.
+
+input
+: linear, RGB, scene-referred.
+
+processing
+: linear, RGB.
+
+output
+: linear, RGB, scene-referred
+{{< /details >}}
+
 Increase the size of the image canvas and fill the additional area with the selected color.
 
 # module controls

--- a/content/module-reference/processing-modules/exposure.md
+++ b/content/module-reference/processing-modules/exposure.md
@@ -4,6 +4,23 @@ id: exposure
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: redo the exposure of the shot as if you were still in-camera using a color-safe brightening similar to increasing ISO setting.
+
+purpose
+: corrective and creative.
+
+input
+: linear, RGB, scene-referred.
+
+processing
+: linear, RGB.
+
+output
+: linear, RGB, scene-referred
+{{< /details >}}
+
 Increase or decrease the overall brightness of an image.
 
 This module has two modes of operation:

--- a/content/module-reference/processing-modules/exposure.md
+++ b/content/module-reference/processing-modules/exposure.md
@@ -4,7 +4,7 @@ id: exposure
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : redo the exposure of the shot as if you were still in-camera using a color-safe brightening similar to increasing ISO setting.
 

--- a/content/module-reference/processing-modules/external-raster.md
+++ b/content/module-reference/processing-modules/external-raster.md
@@ -4,6 +4,23 @@ id: external-raster
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: read PFM/PNG files recorded for use as raster masks.
+
+purpose
+: corrective or creative.
+
+input
+: linear, raw, scene-referred.
+
+processing
+: linear, raw.
+
+output
+: linear, raw, scene-referred
+{{< /details >}}
+
 Generate a raster mask from a `.pfm` to be used by subsequent processing modules.
 
 ---

--- a/content/module-reference/processing-modules/external-raster.md
+++ b/content/module-reference/processing-modules/external-raster.md
@@ -4,7 +4,7 @@ id: external-raster
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : read PFM/PNG files recorded for use as raster masks.
 

--- a/content/module-reference/processing-modules/filmic-rgb.md
+++ b/content/module-reference/processing-modules/filmic-rgb.md
@@ -5,7 +5,7 @@ weight: 10
 include_toc: true
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : apply a view transform to prepare the scene-referred pipeline for display on SDR screens and paper prints while preventing clipping in non-destructive ways.
 

--- a/content/module-reference/processing-modules/filmic-rgb.md
+++ b/content/module-reference/processing-modules/filmic-rgb.md
@@ -5,6 +5,23 @@ weight: 10
 include_toc: true
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: apply a view transform to prepare the scene-referred pipeline for display on SDR screens and paper prints while preventing clipping in non-destructive ways.
+
+purpose
+: corrective and creative.
+
+input
+: linear or non-linear, RGB, scene-referred.
+
+processing
+: non-linear, RGB.
+
+output
+: non-linear, RGB, display-referred
+{{< /details >}}
+
 Remap the tonal range of an image by reproducing the tone and color response of classic film.
 
 This module can be used either to expand or to contract the dynamic range of the scene to fit the dynamic range of the display. It protects colors and contrast in the mid-tones, recovers the shadows, and compresses bright highlights and dark shadows. Highlights will need extra care when details need to be preserved (e.g. clouds).

--- a/content/module-reference/processing-modules/framing.md
+++ b/content/module-reference/processing-modules/framing.md
@@ -4,7 +4,7 @@ id: framing
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : add solid borders or margins around the image.
 

--- a/content/module-reference/processing-modules/framing.md
+++ b/content/module-reference/processing-modules/framing.md
@@ -4,6 +4,23 @@ id: framing
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: add solid borders or margins around the image.
+
+purpose
+: creative.
+
+input
+: linear or non-linear, RGB, display-referred.
+
+processing
+: geometric, RGB.
+
+output
+: linear or non-linear, RGB, display-referred
+{{< /details >}}
+
 Generate a frame around the image. 
 
 The frame consists of a border (with a user-defined color) and a frame line within that border (with a second user-defined color). Various options are available to control the geometry and color of the frame.

--- a/content/module-reference/processing-modules/graduated-density.md
+++ b/content/module-reference/processing-modules/graduated-density.md
@@ -4,7 +4,7 @@ id: graduated-density
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : simulate an optical graduated neutral density filter.
 

--- a/content/module-reference/processing-modules/graduated-density.md
+++ b/content/module-reference/processing-modules/graduated-density.md
@@ -4,6 +4,23 @@ id: graduated-density
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: simulate an optical graduated neutral density filter.
+
+purpose
+: corrective and creative.
+
+input
+: linear or non-linear, RGB, scene-referred.
+
+processing
+: non-linear, RGB.
+
+output
+: non-linear, RGB, display-referred
+{{< /details >}}
+
 Simulate a graduated density filter in order to correct exposure and color in a progressive manner.
 
 A line is shown on screen allowing the position and rotation of the gradient to be modified with the mouse.

--- a/content/module-reference/processing-modules/grain.md
+++ b/content/module-reference/processing-modules/grain.md
@@ -4,6 +4,23 @@ id: grain
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: simulate silver grains from film.
+
+purpose
+: creative.
+
+input
+: non-linear, Lab, display-referred.
+
+processing
+: non-linear, Lab.
+
+output
+: non-linear, Lab, display-referred
+{{< /details >}}
+
 Simulate the grain of analog film. The grain is processed on the L channel of Lab color space.
 
 # module controls

--- a/content/module-reference/processing-modules/grain.md
+++ b/content/module-reference/processing-modules/grain.md
@@ -4,7 +4,7 @@ id: grain
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : simulate silver grains from film.
 

--- a/content/module-reference/processing-modules/haze-removal.md
+++ b/content/module-reference/processing-modules/haze-removal.md
@@ -4,6 +4,23 @@ id: haze-removal
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: remove fog and atmospheric hazing from images.
+
+purpose
+: corrective.
+
+input
+: linear, RGB, scene-referred.
+
+processing
+: frequential, RGB.
+
+output
+: linear, RGB, scene-referred
+{{< /details >}}
+
 Automatically reduce the effect of dust and haze in the atmosphere. This module may also be employed more generally to give images a color boost specifically in low-contrast regions of the image.
 
 Haze absorbs light from objects in the scene but it is also a source of diffuse background light. The haze removal module first estimates, for each image region, the amount of haze in the scene. It then removes the diffuse background light according to its local strength and recovers the original object light.

--- a/content/module-reference/processing-modules/haze-removal.md
+++ b/content/module-reference/processing-modules/haze-removal.md
@@ -4,7 +4,7 @@ id: haze-removal
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : remove fog and atmospheric hazing from images.
 

--- a/content/module-reference/processing-modules/highlight-reconstruction.md
+++ b/content/module-reference/processing-modules/highlight-reconstruction.md
@@ -4,6 +4,23 @@ id: highlight-reconstruction
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: avoid magenta highlights and try to recover highlights colors.
+
+purpose
+: corrective.
+
+input
+: linear, raw, scene-referred.
+
+processing
+: reconstruction, raw.
+
+output
+: linear, raw, scene-referred
+{{< /details >}}
+
 Attempt to reconstruct color information for pixels that are clipped in one or more RGB channel.
 
 # clipping

--- a/content/module-reference/processing-modules/highlight-reconstruction.md
+++ b/content/module-reference/processing-modules/highlight-reconstruction.md
@@ -4,7 +4,7 @@ id: highlight-reconstruction
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : avoid magenta highlights and try to recover highlights colors.
 

--- a/content/module-reference/processing-modules/highpass.md
+++ b/content/module-reference/processing-modules/highpass.md
@@ -4,7 +4,7 @@ id: highpass
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : isolate high frequencies in the image.
 

--- a/content/module-reference/processing-modules/highpass.md
+++ b/content/module-reference/processing-modules/highpass.md
@@ -4,6 +4,23 @@ id: highpass
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: isolate high frequencies in the image.
+
+purpose
+: creative.
+
+input
+: linear or non-linear, Lab, scene-referred.
+
+processing
+: frequential, Lab.
+
+output
+: special, Lab, scene-referred
+{{< /details >}}
+
 A high pass filter. 
 
 This module is primarily intended to be used in combination with a [_blend mode_](../../darkroom/masking-and-blending/blend-modes.md). For example, try using the module with a blend mode of "soft light" for high pass sharpening.

--- a/content/module-reference/processing-modules/hot-pixels.md
+++ b/content/module-reference/processing-modules/hot-pixels.md
@@ -4,6 +4,23 @@ id: hot-pixels
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: remove abnormally bright pixels by dampening them with neighbors.
+
+purpose
+: corrective.
+
+input
+: linear, raw, scene-referred.
+
+processing
+: reconstruction, raw.
+
+output
+: linear, raw, scene-referred
+{{< /details >}}
+
 Automatically detect and eliminate hot pixels. 
 
 Hot pixels are pixels which have failed to record a light level correctly. Detected hot pixels are replaced by an average of their neighbors.

--- a/content/module-reference/processing-modules/hot-pixels.md
+++ b/content/module-reference/processing-modules/hot-pixels.md
@@ -4,7 +4,7 @@ id: hot-pixels
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : remove abnormally bright pixels by dampening them with neighbors.
 

--- a/content/module-reference/processing-modules/input-color-profile.md
+++ b/content/module-reference/processing-modules/input-color-profile.md
@@ -4,7 +4,7 @@ id: input-color-profile
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : convert any RGB input to pipeline reference RGB using color profiles to remap RGB values.
 

--- a/content/module-reference/processing-modules/input-color-profile.md
+++ b/content/module-reference/processing-modules/input-color-profile.md
@@ -4,6 +4,23 @@ id: input-color-profile
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: convert any RGB input to pipeline reference RGB using color profiles to remap RGB values.
+
+purpose
+: mandatory.
+
+input
+: linear or non-linear, RGB, scene-referred.
+
+processing
+: defined by profile.
+
+output
+: linear, RGB, scene-referred
+{{< /details >}}
+
 Define how darktable will interpret the colors of the image. 
 
 This module takes the color space used by the image source (e.g. camera, scanner) and converts the pixel encodings to a standardized working color space. This means that subsequent modules in the pipeline don't need to be concerned with the specifics of the input device, and can work with and convert to/from a common working color space.

--- a/content/module-reference/processing-modules/invert.md
+++ b/content/module-reference/processing-modules/invert.md
@@ -6,7 +6,7 @@ weight: 20
 
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : invert film negatives.
 

--- a/content/module-reference/processing-modules/invert.md
+++ b/content/module-reference/processing-modules/invert.md
@@ -6,6 +6,23 @@ weight: 20
 
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: invert film negatives.
+
+purpose
+: corrective.
+
+input
+: linear, raw, display-referred.
+
+processing
+: linear, raw.
+
+output
+: linear, raw, display-referred
+{{< /details >}}
+
 **Please note that this module is [deprecated](../../darkroom/processing-modules/deprecated.md) from darktable 3.4 and should no longer be used for new edits. Please use the [_negadoctor_](./negadoctor.md) module instead.**
 
 ---

--- a/content/module-reference/processing-modules/lens-correction.md
+++ b/content/module-reference/processing-modules/lens-correction.md
@@ -4,6 +4,23 @@ id: lens-correction
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: correct lenses optical flaws.
+
+purpose
+: corrective.
+
+input
+: linear, RGB, scene-referred.
+
+processing
+: geometric and reconstruction, RGB.
+
+output
+: linear, RGB, scene-referred
+{{< /details >}}
+
 Automatically correct for (or simulate) lens distortion, transverse chromatic aberrations (TCA) and vignetting.
 
 You can choose to either use lens correction data embedded in your Raw file (where present/supported) or correction data provided by the external [Lensfun library](https://lensfun.github.io/).

--- a/content/module-reference/processing-modules/lens-correction.md
+++ b/content/module-reference/processing-modules/lens-correction.md
@@ -4,7 +4,7 @@ id: lens-correction
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : correct lenses optical flaws.
 

--- a/content/module-reference/processing-modules/levels.md
+++ b/content/module-reference/processing-modules/levels.md
@@ -6,7 +6,7 @@ weight: 20
 
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : adjust black, white and mid-gray points.
 

--- a/content/module-reference/processing-modules/levels.md
+++ b/content/module-reference/processing-modules/levels.md
@@ -6,6 +6,23 @@ weight: 20
 
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: adjust black, white and mid-gray points.
+
+purpose
+: creative.
+
+input
+: linear or non-linear, Lab, display-referred.
+
+processing
+: non-linear, Lab.
+
+output
+: non-linear, Lab, display-referred
+{{< /details >}}
+
 **Please note that this module is [deprecated](../../darkroom/processing-modules/deprecated.md) from darktable 4.4 and should no longer be used for new edits. Please use the [_rgb levels_](./rgb-levels.md) module instead.**
 
 ---

--- a/content/module-reference/processing-modules/liquify.md
+++ b/content/module-reference/processing-modules/liquify.md
@@ -4,7 +4,7 @@ id: liquify
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : distort parts of the image.
 

--- a/content/module-reference/processing-modules/liquify.md
+++ b/content/module-reference/processing-modules/liquify.md
@@ -4,6 +4,23 @@ id: liquify
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: distort parts of the image.
+
+purpose
+: creative.
+
+input
+: linear, RGB, scene-referred.
+
+processing
+: geometric, RGB.
+
+output
+: linear, RGB, scene-referred
+{{< /details >}}
+
 Move pixels around by applying freestyle distortions to parts of the image using points, lines and curves.
 
 As you might want to use source data from any part of the image you will be shown the uncropped image (possibly with the cropping rectangle overlaid as a guide) while the module is active.

--- a/content/module-reference/processing-modules/local-contrast.md
+++ b/content/module-reference/processing-modules/local-contrast.md
@@ -4,6 +4,23 @@ id: local-contrast
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: manipulate local and global contrast separately.
+
+purpose
+: creative.
+
+input
+: non-linear, Lab, display-referred.
+
+processing
+: non-linear, Lab.
+
+output
+: non-linear, Lab, display-referred
+{{< /details >}}
+
 Enhance the image's local contrast.
 
 This is achieved using either a _local laplacian_ (default) or _unnormalized bilateral_ filter. Both modes work exclusively on the L channel from Lab. The _local laplacian_ filter has been designed to be robust against unwanted halo effects and gradient reversals along edges.

--- a/content/module-reference/processing-modules/local-contrast.md
+++ b/content/module-reference/processing-modules/local-contrast.md
@@ -4,7 +4,7 @@ id: local-contrast
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : manipulate local and global contrast separately.
 

--- a/content/module-reference/processing-modules/lowlight-vision.md
+++ b/content/module-reference/processing-modules/lowlight-vision.md
@@ -4,6 +4,23 @@ id: lowlight-vision
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: simulate human night vision.
+
+purpose
+: creative.
+
+input
+: non-linear, Lab, display-referred.
+
+processing
+: linear, XYZ.
+
+output
+: non-linear, Lab, display-referred
+{{< /details >}}
+
 Simulate human lowlight vision. This module can also be used to perform a day-to-night conversion.
 
 The idea is to calculate a [scotopic vision](http://en.wikipedia.org/wiki/Scotopic_vision) image, which is perceived by the rods rather than the cones in the eyes under low light. Scotopic lightness is then mixed with photopic value (regular color image pixel) using some blending function. This module can also simulate the [Purkinje effect](http://en.wikipedia.org/wiki/Purkinje_effect) by adding some blueness to the dark parts of the image.

--- a/content/module-reference/processing-modules/lowlight-vision.md
+++ b/content/module-reference/processing-modules/lowlight-vision.md
@@ -4,7 +4,7 @@ id: lowlight-vision
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : simulate human night vision.
 

--- a/content/module-reference/processing-modules/lowpass.md
+++ b/content/module-reference/processing-modules/lowpass.md
@@ -4,7 +4,7 @@ id: lowpass
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : isolate low frequencies in the image.
 

--- a/content/module-reference/processing-modules/lowpass.md
+++ b/content/module-reference/processing-modules/lowpass.md
@@ -4,6 +4,23 @@ id: lowpass
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: isolate low frequencies in the image.
+
+purpose
+: creative.
+
+input
+: linear or non-linear, Lab, scene-referred.
+
+processing
+: frequential, Lab.
+
+output
+: special, Lab, scene-referred
+{{< /details >}}
+
 Apply a low pass filter (for example, a Gaussian blur) to the image, while controlling the output contrast and saturation. 
 
 This module is primarily intended to be used in combination with a [blend mode](../../darkroom/masking-and-blending/blend-modes.md). For example, try using the _local contrast mask_ preset with the _overlay_ blend mode.

--- a/content/module-reference/processing-modules/lut-3D.md
+++ b/content/module-reference/processing-modules/lut-3D.md
@@ -4,7 +4,7 @@ id: lut-3d
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : perform color space corrections and apply look.
 

--- a/content/module-reference/processing-modules/lut-3D.md
+++ b/content/module-reference/processing-modules/lut-3D.md
@@ -4,6 +4,23 @@ id: lut-3d
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: perform color space corrections and apply look.
+
+purpose
+: corrective or creative.
+
+input
+: linear, RGB, display-referred.
+
+processing
+: defined by profile, RGB.
+
+output
+: linear or non-linear, RGB, display-referred
+{{< /details >}}
+
 Transform RGB values with a 3D LUT file.
 
 A 3D LUT is a tridimensional table that is used to transform a given RGB value into another RGB value. It is normally used for film simulation and color grading.

--- a/content/module-reference/processing-modules/monochrome.md
+++ b/content/module-reference/processing-modules/monochrome.md
@@ -4,7 +4,7 @@ id: monochrome
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : quickly convert an image to black & white using a variable color filter.
 

--- a/content/module-reference/processing-modules/monochrome.md
+++ b/content/module-reference/processing-modules/monochrome.md
@@ -4,6 +4,23 @@ id: monochrome
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: quickly convert an image to black & white using a variable color filter.
+
+purpose
+: creative.
+
+input
+: linear or non-linear, Lab, display-referred.
+
+processing
+: non-linear, Lab.
+
+output
+: non-linear, Lab, display-referred
+{{< /details >}}
+
 Quickly convert an image to black & white using a variable color filter.
 
 To use this module, first reduce the filter size (to concentrate its effect) and move it across the hue palette to find the best filter value for your desired image rendition. Then gradually expand the filter to include more hues and achieve more natural tonality.

--- a/content/module-reference/processing-modules/negadoctor.md
+++ b/content/module-reference/processing-modules/negadoctor.md
@@ -4,6 +4,23 @@ id: negadoctor
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: invert film negative scans and simulate printing on paper.
+
+purpose
+: corrective and creative.
+
+input
+: linear, RGB, display-referred.
+
+processing
+: non-linear, RGB.
+
+output
+: non-linear, RGB, display-referred
+{{< /details >}}
+
 Process scanned film negatives. 
 
 You can obtain an image of a negative using a film scanner, or by photographing it against a white light (e.g. a light table or computer monitor) or off-camera flash.

--- a/content/module-reference/processing-modules/negadoctor.md
+++ b/content/module-reference/processing-modules/negadoctor.md
@@ -4,7 +4,7 @@ id: negadoctor
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : invert film negative scans and simulate printing on paper.
 

--- a/content/module-reference/processing-modules/orientation.md
+++ b/content/module-reference/processing-modules/orientation.md
@@ -4,7 +4,7 @@ id: orientation
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : flip or rotate image by step of 90 degrees.
 

--- a/content/module-reference/processing-modules/orientation.md
+++ b/content/module-reference/processing-modules/orientation.md
@@ -4,6 +4,23 @@ id: orientation
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: flip or rotate image by step of 90 degrees.
+
+purpose
+: corrective.
+
+input
+: linear, RGB, scene-referred.
+
+processing
+: geometric, RGB.
+
+output
+: linear, RGB, scene-referred
+{{< /details >}}
+
 Rotate the image 90 degrees at a time or flip the image horizontally and/or vertically.
 
 The module is enabled by default and the orientation (rotation) is automatically set based on the image's Exif data.

--- a/content/module-reference/processing-modules/output-color-profile.md
+++ b/content/module-reference/processing-modules/output-color-profile.md
@@ -4,6 +4,23 @@ id: output-color-profile
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: convert pipeline reference RGB to any display RGB using color profiles to remap RGB values.
+
+purpose
+: mandatory.
+
+input
+: linear or non-linear, Lab, display-referred.
+
+processing
+: defined by profile.
+
+output
+: non-linear, RGB or Lab, display-referred
+{{< /details >}}
+
 Manage the output profile for export and the rendering intent to be used when mapping between color spaces.
 
 darktable comes with pre-defined profiles _sRGB_, _Adobe RGB_, _XYZ_ and _linear RGB_. You can provide additional profiles by placing them in `$DARKTABLE/share/darktable/color/out` and `$HOME/.config/darktable/color/out` (where `$DARKTABLE` is the darktable installation directory and `$HOME` is your home directory). Note that these `color/out` directories are not created by the darktable install; if you need to use one, you must create it yourself.

--- a/content/module-reference/processing-modules/output-color-profile.md
+++ b/content/module-reference/processing-modules/output-color-profile.md
@@ -4,7 +4,7 @@ id: output-color-profile
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : convert pipeline reference RGB to any display RGB using color profiles to remap RGB values.
 

--- a/content/module-reference/processing-modules/raw-black-white-point.md
+++ b/content/module-reference/processing-modules/raw-black-white-point.md
@@ -4,7 +4,7 @@ id: raw-black-white-point
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : sets technical specificities of the raw sensor  touch with great care!.
 

--- a/content/module-reference/processing-modules/raw-black-white-point.md
+++ b/content/module-reference/processing-modules/raw-black-white-point.md
@@ -4,6 +4,23 @@ id: raw-black-white-point
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: sets technical specificities of the raw sensor  touch with great care!.
+
+purpose
+: mandatory.
+
+input
+: linear, raw, scene-referred.
+
+processing
+: linear, raw.
+
+output
+: linear, raw, scene-referred
+{{< /details >}}
+
 Define camera-specific black and white points. 
 
 This module is activated automatically for all raw images. Default settings are applied for all supported cameras. Changes to the defaults are not normally required.

--- a/content/module-reference/processing-modules/raw-chromatic-aberrations.md
+++ b/content/module-reference/processing-modules/raw-chromatic-aberrations.md
@@ -4,6 +4,23 @@ id: raw-chromatic-aberrations
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: correct chromatic aberrations for Bayer sensors.
+
+purpose
+: corrective.
+
+input
+: linear, raw, scene-referred.
+
+processing
+: linear, raw.
+
+output
+: linear, raw, scene-referred
+{{< /details >}}
+
 Correct chromatic aberrations of raw images.
 
 This module currently only works for raw images recorded with a Bayer sensor (the sensor used in the majority of cameras) -- for other types of image, you should use the [_chromatic aberrations_](./chromatic-aberrations.md) module instead.

--- a/content/module-reference/processing-modules/raw-chromatic-aberrations.md
+++ b/content/module-reference/processing-modules/raw-chromatic-aberrations.md
@@ -4,7 +4,7 @@ id: raw-chromatic-aberrations
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : correct chromatic aberrations for Bayer sensors.
 

--- a/content/module-reference/processing-modules/raw-denoise.md
+++ b/content/module-reference/processing-modules/raw-denoise.md
@@ -4,6 +4,23 @@ id: raw-denoise
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: denoise the raw image early in the pipeline.
+
+purpose
+: corrective.
+
+input
+: linear, raw, scene-referred.
+
+processing
+: linear, raw.
+
+output
+: linear, raw, scene-referred
+{{< /details >}}
+
 Perform denoising on raw image data before it is [demosaiced](./demosaic.md). 
 
 This module has been ported from [dcraw](https://www.dechifro.org/dcraw/).

--- a/content/module-reference/processing-modules/raw-denoise.md
+++ b/content/module-reference/processing-modules/raw-denoise.md
@@ -4,7 +4,7 @@ id: raw-denoise
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : denoise the raw image early in the pipeline.
 

--- a/content/module-reference/processing-modules/retouch.md
+++ b/content/module-reference/processing-modules/retouch.md
@@ -4,6 +4,23 @@ id: retouch
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: remove and clone spots, perform split-frequency skin editing.
+
+purpose
+: corrective.
+
+input
+: linear, RGB, scene-referred.
+
+processing
+: geometric and frequential, RGB.
+
+output
+: linear, RGB, scene-referred
+{{< /details >}}
+
 Remove unwanted elements from your image by cloning, healing, blurring and filling using drawn shapes.
 
 This module extends the capabilities of the deprecated [_spot removal_](./spot-removal.md) module (equivalent to this module's "clone" tool) by including a "heal" tool (based on the heal tool from GIMP), as well as "fill" and "blur" modes. It can also take advantage of [wavelet decomposition](../../darkroom/processing-modules/wavelets.md), allowing the image to be separated into layers of varying detail (from coarse to fine) which can be selectively retouched before being recombined to produce the output image.

--- a/content/module-reference/processing-modules/retouch.md
+++ b/content/module-reference/processing-modules/retouch.md
@@ -4,7 +4,7 @@ id: retouch
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : remove and clone spots, perform split-frequency skin editing.
 

--- a/content/module-reference/processing-modules/rgb-curve.md
+++ b/content/module-reference/processing-modules/rgb-curve.md
@@ -4,7 +4,7 @@ id: rgb-curve
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : alter an image’s tones using curves in RGB color space.
 

--- a/content/module-reference/processing-modules/rgb-curve.md
+++ b/content/module-reference/processing-modules/rgb-curve.md
@@ -4,6 +4,23 @@ id: rgb-curve
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: alter an image’s tones using curves in RGB color space.
+
+purpose
+: corrective and creative.
+
+input
+: linear, RGB, display-referred.
+
+processing
+: non-linear, RGB.
+
+output
+: linear, RGB, display-referred
+{{< /details >}}
+
 A classic digital photography tool to alter an image's tones using curves.
 
 This module is very similar to the [_tone curve_](./tone-curve.md) module but works in RGB color space.

--- a/content/module-reference/processing-modules/rgb-levels.md
+++ b/content/module-reference/processing-modules/rgb-levels.md
@@ -4,7 +4,7 @@ id: rgb-levels
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : adjust black, white and mid-gray points in RGB color space.
 

--- a/content/module-reference/processing-modules/rgb-levels.md
+++ b/content/module-reference/processing-modules/rgb-levels.md
@@ -4,6 +4,23 @@ id: rgb-levels
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: adjust black, white and mid-gray points in RGB color space.
+
+purpose
+: corrective and creative.
+
+input
+: linear, RGB, display-referred.
+
+processing
+: non-linear, RGB.
+
+output
+: non-linear, RGB, display-referred
+{{< /details >}}
+
 Adjust black, white and mid-gray points in RGB color space. This module is similar to the [_levels_](./levels.md) module, which works in Lab color space.
 
 The rgb levels tool shows a histogram of the image, and displays three bars with handles. Drag the handles to modify the black, middle-gray and white points in lightness (in "RGB, linked channels" mode) or independently for each of the R, G and B channels (in "RGB, independent channels" mode).

--- a/content/module-reference/processing-modules/rgb-primaries.md
+++ b/content/module-reference/processing-modules/rgb-primaries.md
@@ -4,6 +4,23 @@ id: rgb-primaries
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: adjustment of the RGB color primaries for color grading.
+
+purpose
+: corrective or creative.
+
+input
+: linear, RGB, scene-referred.
+
+processing
+: linear, RGB.
+
+output
+: linear, RGB, scene-referred
+{{< /details >}}
+
 Adjust the hue and [purity](../../special-topics/color-management/color-dimensions.md#definitions) of the RGB primary colors (i.e. _which_ red, green and blue they represent), while leaving uncolored (gray) pixels unchanged. In addition to preserving gray pixels, the opponency relationships between the colors are also preserved under this adjustment: If you increase the purity of the blue primary, the opponent yellow's intensity increases to balance things out; If you twist the blue hue toward cyan, the opponent yellow is twisted toward orange.
 
 This module is essentially a channel mixer (as in the [color calibration](./color-calibration.md) module) but with a different interface. Even though the sliders are named "red", "green" and "blue", all adjustments are global and affect the overall colorimetry of the image, just like a channel mixer does.

--- a/content/module-reference/processing-modules/rgb-primaries.md
+++ b/content/module-reference/processing-modules/rgb-primaries.md
@@ -4,7 +4,7 @@ id: rgb-primaries
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : adjustment of the RGB color primaries for color grading.
 

--- a/content/module-reference/processing-modules/rotate-perspective.md
+++ b/content/module-reference/processing-modules/rotate-perspective.md
@@ -4,7 +4,7 @@ id: rotate-perspective
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : rotate or distort perspective.
 

--- a/content/module-reference/processing-modules/rotate-perspective.md
+++ b/content/module-reference/processing-modules/rotate-perspective.md
@@ -4,6 +4,23 @@ id: rotate-perspective
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: rotate or distort perspective.
+
+purpose
+: corrective or creative.
+
+input
+: linear, RGB, scene-referred.
+
+processing
+: geometric, RGB.
+
+output
+: linear, RGB, scene-referred
+{{< /details >}}
+
 Automatically correct for converging lines, a form of perspective distortion. The underlying mechanism is inspired by Markus Hebel's [_ShiftN_](http://www.shiftn.de/) program. This module also allows for the rotation of the image to be adjusted.
 
 Perspective distortions are a natural effect when projecting a three dimensional scene onto a two dimensional plane and cause objects close to the viewer to appear larger than objects further away. Converging lines are a special case of perspective distortions frequently seen in architectural photographs -- parallel lines, when photographed at an angle, are transformed into converging lines that meet at some vantage point within or outside of the image frame.

--- a/content/module-reference/processing-modules/rotate-pixels.md
+++ b/content/module-reference/processing-modules/rotate-pixels.md
@@ -4,6 +4,23 @@ id: rotate-pixels
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: null
+
+purpose
+: null
+
+input
+: null
+
+processing
+: null
+
+output
+: null
+{{< /details >}}
+
 The sensors of some cameras (such as the Fujifilm FinePix S2Pro, F700, and E550) have a diagonally oriented Bayer pattern instead of the usual orthogonal layout.
 
 Without correction this would lead to a tilted image with black corners. This module applies the required rotation.

--- a/content/module-reference/processing-modules/rotate-pixels.md
+++ b/content/module-reference/processing-modules/rotate-pixels.md
@@ -4,7 +4,7 @@ id: rotate-pixels
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : null
 

--- a/content/module-reference/processing-modules/scale-pixels.md
+++ b/content/module-reference/processing-modules/scale-pixels.md
@@ -4,6 +4,23 @@ id: scale-pixels
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: module for setting pixel aspect ratio  useful for certain sensor types and anamorphic desqueeze.
+
+purpose
+: corrective.
+
+input
+: linear, RGB, scene-referred.
+
+processing
+: linear, RGB.
+
+output
+: linear, RGB, scene-referred
+{{< /details >}}
+
 Some cameras (such as the Nikon D1X) have rectangular instead of the usual square sensor cells. Without correction this would lead to distorted images. This module applies the required scaling.
 
 darktable detects images that need correction using their Exif data and automatically activates this module where required.

--- a/content/module-reference/processing-modules/scale-pixels.md
+++ b/content/module-reference/processing-modules/scale-pixels.md
@@ -4,7 +4,7 @@ id: scale-pixels
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : module for setting pixel aspect ratio  useful for certain sensor types and anamorphic desqueeze.
 

--- a/content/module-reference/processing-modules/shadows-and-highlights.md
+++ b/content/module-reference/processing-modules/shadows-and-highlights.md
@@ -4,7 +4,7 @@ id: shadows-and-highlights
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : modify the tonal range of the shadows and highlights of an image by enhancing local contrast.
 

--- a/content/module-reference/processing-modules/shadows-and-highlights.md
+++ b/content/module-reference/processing-modules/shadows-and-highlights.md
@@ -4,6 +4,23 @@ id: shadows-and-highlights
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: modify the tonal range of the shadows and highlights of an image by enhancing local contrast.
+
+purpose
+: corrective and creative.
+
+input
+: linear or non-linear, Lab, display-referred.
+
+processing
+: non-linear, Lab.
+
+output
+: non-linear, Lab, display-referred
+{{< /details >}}
+
 Modify the tonal range of the shadows and highlights of an image by enhancing local contrast.
 
 ---

--- a/content/module-reference/processing-modules/sharpen.md
+++ b/content/module-reference/processing-modules/sharpen.md
@@ -4,6 +4,23 @@ id: sharpen
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: sharpen the details in the image using a standard UnSharp Mask (USM).
+
+purpose
+: corrective.
+
+input
+: linear or non-linear, Lab, display or scene-referred.
+
+processing
+: frequential, Lab.
+
+output
+: quasi-linear, Lab, display or scene-referred
+{{< /details >}}
+
 Sharpen the details in the image using a standard UnSharp Mask (USM). 
 
 This module works by increasing the contrast around edges and thereby enhancing the _impression_ of sharpness of an image. This module is applied to the L channel in Lab color space.

--- a/content/module-reference/processing-modules/sharpen.md
+++ b/content/module-reference/processing-modules/sharpen.md
@@ -4,7 +4,7 @@ id: sharpen
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : sharpen the details in the image using a standard UnSharp Mask (USM).
 

--- a/content/module-reference/processing-modules/sigmoid.md
+++ b/content/module-reference/processing-modules/sigmoid.md
@@ -4,6 +4,23 @@ id: sigmoid
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: apply a view transform to make an image displayable on a screen or print using a robust and smooth tone curve with optional color preservation methods.
+
+purpose
+: corrective and creative.
+
+input
+: linear, RGB, scene-referred.
+
+processing
+: non-linear, RGB.
+
+output
+: linear, RGB, display-referred
+{{< /details >}}
+
 Remap the tonal range of an image using a modified generalized log-logistic curve.
 
 This module can be used to expand or contract the dynamic range of the scene to fit the dynamic range of the display.

--- a/content/module-reference/processing-modules/sigmoid.md
+++ b/content/module-reference/processing-modules/sigmoid.md
@@ -4,7 +4,7 @@ id: sigmoid
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : apply a view transform to make an image displayable on a screen or print using a robust and smooth tone curve with optional color preservation methods.
 

--- a/content/module-reference/processing-modules/soften.md
+++ b/content/module-reference/processing-modules/soften.md
@@ -4,6 +4,23 @@ id: soften
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: create a softened image using the Orton effect.
+
+purpose
+: creative.
+
+input
+: linear, RGB, display-referred.
+
+processing
+: linear, RGB.
+
+output
+: linear, RGB, display-referred
+{{< /details >}}
+
 Create a softened image using the [Orton effect](https://en.wikipedia.org/wiki/Orton_(photography)).
 
 Michael Orton achieved his results on slide film by using two exposures of the same scene, one well exposed and one overexposed. He then used a darkroom technique to blend these two images into a final image where the overexposed image was blurred.

--- a/content/module-reference/processing-modules/soften.md
+++ b/content/module-reference/processing-modules/soften.md
@@ -4,7 +4,7 @@ id: soften
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : create a softened image using the Orton effect.
 

--- a/content/module-reference/processing-modules/split-toning.md
+++ b/content/module-reference/processing-modules/split-toning.md
@@ -4,6 +4,23 @@ id: split-toning
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: use two specific colors for shadows and highlights and create a linear toning effect between them up to a pivot.
+
+purpose
+: creative.
+
+input
+: linear, RGB, scene-referred.
+
+processing
+: linear, RGB.
+
+output
+: linear, RGB, scene-referred
+{{< /details >}}
+
 Create a two color linear toning effect where the shadows and highlights are represented by two different colors.
 
 The split-toning module does not convert images to black and white and has limited benefits on color images. In order to perform traditional split-toning, the input to this module should therefore be monochrome.

--- a/content/module-reference/processing-modules/split-toning.md
+++ b/content/module-reference/processing-modules/split-toning.md
@@ -4,7 +4,7 @@ id: split-toning
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : use two specific colors for shadows and highlights and create a linear toning effect between them up to a pivot.
 

--- a/content/module-reference/processing-modules/spot-removal.md
+++ b/content/module-reference/processing-modules/spot-removal.md
@@ -6,6 +6,23 @@ weight: 20
 
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: remove sensor dust spots.
+
+purpose
+: corrective.
+
+input
+: linear, RGB, scene-referred.
+
+processing
+: geometric, raw.
+
+output
+: linear, RGB, scene-referred
+{{< /details >}}
+
 **Please note that this module is [deprecated](../../darkroom/processing-modules/deprecated.md) from darktable 3.6 and should no longer be used for new edits. Please use the "cloning" tool in the [_retouch_](./retouch.md) module instead.**
 
 ---

--- a/content/module-reference/processing-modules/spot-removal.md
+++ b/content/module-reference/processing-modules/spot-removal.md
@@ -6,7 +6,7 @@ weight: 20
 
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : remove sensor dust spots.
 

--- a/content/module-reference/processing-modules/surface-blur.md
+++ b/content/module-reference/processing-modules/surface-blur.md
@@ -4,6 +4,23 @@ id: surface-blur
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: apply edge-aware surface blur to denoise or smoothen textures.
+
+purpose
+: corrective and creative.
+
+input
+: linear, RGB, scene-referred.
+
+processing
+: linear, RGB.
+
+output
+: linear, RGB, scene-referred
+{{< /details >}}
+
 Smooth image surfaces while preserving sharp edges using a bilateral filter. 
 
 This module _can_ be used to denoise images, however you should be aware that bilateral filters are susceptible to overshoots and darktable offers much better alternatives. For example, the [_astrophoto denoise_](./astrophoto-denoise.md) module uses a non-local means denoising algorithm, and the [_denoise (profiled)_](./denoise-profiled.md) module provides a choice between non-local means and wavelet denoising algorithms. 

--- a/content/module-reference/processing-modules/surface-blur.md
+++ b/content/module-reference/processing-modules/surface-blur.md
@@ -4,7 +4,7 @@ id: surface-blur
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : apply edge-aware surface blur to denoise or smoothen textures.
 

--- a/content/module-reference/processing-modules/tone-curve.md
+++ b/content/module-reference/processing-modules/tone-curve.md
@@ -4,6 +4,23 @@ id: tone-curve
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: alter an image’s tones using curves.
+
+purpose
+: corrective and creative.
+
+input
+: linear or non-linear, Lab, display-referred.
+
+processing
+: non-linear, Lab.
+
+output
+: non-linear, Lab, display-referred
+{{< /details >}}
+
 A classic digital photography tool to alter the tones of an image's using curves.
 
 This module is very similar to the [_rgb curve_](./rgb-curve.md) module but works in Lab color space.

--- a/content/module-reference/processing-modules/tone-curve.md
+++ b/content/module-reference/processing-modules/tone-curve.md
@@ -4,7 +4,7 @@ id: tone-curve
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : alter an image’s tones using curves.
 

--- a/content/module-reference/processing-modules/tone-equalizer.md
+++ b/content/module-reference/processing-modules/tone-equalizer.md
@@ -4,7 +4,7 @@ id: tone-equalizer
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : relight the scene as if the lighting was done directly on the scene.
 

--- a/content/module-reference/processing-modules/tone-equalizer.md
+++ b/content/module-reference/processing-modules/tone-equalizer.md
@@ -4,6 +4,23 @@ id: tone-equalizer
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: relight the scene as if the lighting was done directly on the scene.
+
+purpose
+: corrective and creative.
+
+input
+: linear, RGB, scene-referred.
+
+processing
+: quasi-linear, RGB.
+
+output
+: quasi-linear, RGB, scene-referred
+{{< /details >}}
+
 Dodge and burn while preserving local contrast.
 
 The _tone equalizer_ module replaces the need for other tone-mapping modules such as the [_shadows and highlights_](./shadows-and-highlights.md), [_tone curve_](./tone-curve.md), [_zone system (deprecated)_](./zone-system.md), and similar modules. It works in linear RGB space and utilizes a user-defined mask to guide the dodging and burning adjustments, helping to preserve local contrast within the image.

--- a/content/module-reference/processing-modules/unbreak-input-profile.md
+++ b/content/module-reference/processing-modules/unbreak-input-profile.md
@@ -4,6 +4,23 @@ id: unbreak-input-profile
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: correct input color profiles meant to be applied on non-linear RGB.
+
+purpose
+: corrective.
+
+input
+: linear, RGB, display-referred.
+
+processing
+: non-linear, RGB.
+
+output
+: non-linear, RGB, display-referred
+{{< /details >}}
+
 Add a correction curve to image data. This is required if you have selected certain input profiles in the [_input color profile_](./input-color-profile.md) module.
 
 If you decide to use an ICC profile from the camera manufacturer in the [_input color profile_](./input-color-profile.md) module, a correction curve frequently needs to be pre-applied to image data to prevent the final output from looking too dark. This extra processing is not required if you use darktable's standard or enhanced color matrices. 

--- a/content/module-reference/processing-modules/unbreak-input-profile.md
+++ b/content/module-reference/processing-modules/unbreak-input-profile.md
@@ -4,7 +4,7 @@ id: unbreak-input-profile
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : correct input color profiles meant to be applied on non-linear RGB.
 

--- a/content/module-reference/processing-modules/velvia.md
+++ b/content/module-reference/processing-modules/velvia.md
@@ -4,6 +4,23 @@ id: velvia
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: resaturate giving more weight to blacks, whites and low-saturation pixels.
+
+purpose
+: creative.
+
+input
+: linear, RGB, scene-referred.
+
+processing
+: linear, RGB.
+
+output
+: linear, RGB, scene-referred
+{{< /details >}}
+
 Resaturate pixels in a weighted manner that gives more weight to blacks, whites and less saturated pixels. 
 
 ---

--- a/content/module-reference/processing-modules/velvia.md
+++ b/content/module-reference/processing-modules/velvia.md
@@ -4,7 +4,7 @@ id: velvia
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : resaturate giving more weight to blacks, whites and low-saturation pixels.
 

--- a/content/module-reference/processing-modules/vibrance.md
+++ b/content/module-reference/processing-modules/vibrance.md
@@ -6,7 +6,7 @@ weight: 20
 
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : saturate and reduce the lightness of the most saturated pixels to make the colors more vivid.
 

--- a/content/module-reference/processing-modules/vibrance.md
+++ b/content/module-reference/processing-modules/vibrance.md
@@ -6,6 +6,23 @@ weight: 20
 
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: saturate and reduce the lightness of the most saturated pixels to make the colors more vivid.
+
+purpose
+: creative.
+
+input
+: linear or non-linear, Lab, display-referred.
+
+processing
+: non-linear, Lab.
+
+output
+: non-linear, Lab, display-referred
+{{< /details >}}
+
 **Please note that this module is [deprecated](../../darkroom/processing-modules/deprecated.md) from darktable 3.6 and should no longer be used for new edits. Please use the vibrance control in the [_color balance rgb_](./color-balance-rgb.md) module instead.**
 
 ---

--- a/content/module-reference/processing-modules/vignetting.md
+++ b/content/module-reference/processing-modules/vignetting.md
@@ -4,6 +4,23 @@ id: vignetting
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: simulate a lens fall-off close to edges.
+
+purpose
+: creative.
+
+input
+: non-linear, RGB, display-referred.
+
+processing
+: non-linear, RGB.
+
+output
+: non-linear, RGB, display-referred
+{{< /details >}}
+
 Apply a vignetting effect to the image. 
 
 Vignetting is a modification of the brightness and saturation at the borders of the image in a specified shape. Many of the parameters listed below can also be modified with a graphical control that overlays the image when the module has focus, showing the shape and extent of the effect.

--- a/content/module-reference/processing-modules/vignetting.md
+++ b/content/module-reference/processing-modules/vignetting.md
@@ -4,7 +4,7 @@ id: vignetting
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : simulate a lens fall-off close to edges.
 

--- a/content/module-reference/processing-modules/watermark.md
+++ b/content/module-reference/processing-modules/watermark.md
@@ -4,6 +4,23 @@ id: watermark
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: overlay an SVG watermark like a signature on the image.
+
+purpose
+: creative.
+
+input
+: non-linear, RGB, display-referred.
+
+processing
+: non-linear, RGB.
+
+output
+: non-linear, RGB, display-referred
+{{< /details >}}
+
 Render a vector-based overlay onto your image. Watermarks are standard SVG documents and can be designed using [Inkscape](http://www.inkscape.org/).
 
 You can also use bitmap (PNG) images.

--- a/content/module-reference/processing-modules/watermark.md
+++ b/content/module-reference/processing-modules/watermark.md
@@ -4,7 +4,7 @@ id: watermark
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : overlay an SVG watermark like a signature on the image.
 

--- a/content/module-reference/processing-modules/white-balance.md
+++ b/content/module-reference/processing-modules/white-balance.md
@@ -4,6 +4,23 @@ id: white-balance
 weight: 10
 ---
 
+{{< details summary="Synopsis" class="synopsis" >}}
+description
+: scale raw RGB channels to balance white and help demosaicing.
+
+purpose
+: corrective.
+
+input
+: linear, raw, scene-referred.
+
+processing
+: linear, raw.
+
+output
+: linear, raw, scene-referred
+{{< /details >}}
+
 Adjust the white balance of the image by altering the temperature and tint, defining a coefficient for each RGB channel, or choosing from list of predefined white balance settings.
 
 The default settings for this module are derived from the camera white balance stored in the image's Exif data.

--- a/content/module-reference/processing-modules/white-balance.md
+++ b/content/module-reference/processing-modules/white-balance.md
@@ -4,7 +4,7 @@ id: white-balance
 weight: 10
 ---
 
-{{< details summary="Synopsis" class="synopsis" >}}
+{{< details summary="Technical information" class="technical-info" >}}
 description
 : scale raw RGB channels to balance white and help demosaicing.
 

--- a/themes/hugo-darktable-docs-epub-theme/assets/sass/modules/typography.scss
+++ b/themes/hugo-darktable-docs-epub-theme/assets/sass/modules/typography.scss
@@ -138,7 +138,7 @@ hr
 }
 
 /* details shortcode styling: add box round contents when open */
-details.synopsis[open]::details-content {
+details.technical-info[open]::details-content {
   padding-left: 2em;
   border: thin solid gray;
 }

--- a/themes/hugo-darktable-docs-epub-theme/assets/sass/modules/typography.scss
+++ b/themes/hugo-darktable-docs-epub-theme/assets/sass/modules/typography.scss
@@ -136,3 +136,9 @@ hr
    margin-top: 1em;
    margin-bottom: 1em;
 }
+
+/* details shortcode styling: add box round contents when open */
+details.synopsis[open]::details-content {
+  padding-left: 2em;
+  border: thin solid gray;
+}

--- a/themes/hugo-darktable-docs-pdf-theme/assets/sass/modules/typography.scss
+++ b/themes/hugo-darktable-docs-pdf-theme/assets/sass/modules/typography.scss
@@ -137,3 +137,13 @@
 {
    display: none;
 }
+
+/* details shortcode styling: add box round contents */
+details.synopsis {
+  border: thin solid gray;
+  padding-left: 2em;
+}
+
+details.synopsis > summary {
+  font-weight: bold;
+}

--- a/themes/hugo-darktable-docs-pdf-theme/assets/sass/modules/typography.scss
+++ b/themes/hugo-darktable-docs-pdf-theme/assets/sass/modules/typography.scss
@@ -139,11 +139,11 @@
 }
 
 /* details shortcode styling: add box round contents */
-details.synopsis {
+details.technical-info {
   border: thin solid gray;
   padding-left: 2em;
 }
 
-details.synopsis > summary {
+details.technical-info > summary {
   font-weight: bold;
 }

--- a/themes/hugo-darktable-docs-theme/assets/sass/modules/typography.scss
+++ b/themes/hugo-darktable-docs-theme/assets/sass/modules/typography.scss
@@ -148,7 +148,7 @@ h3.translations_head
 }
 
 /* details shortcode styling: add box round contents when open */
-details.synopsis[open]::details-content {
+details.technical-info[open]::details-content {
   padding-left: 2em;
   border: thin solid gray;
 }

--- a/themes/hugo-darktable-docs-theme/assets/sass/modules/typography.scss
+++ b/themes/hugo-darktable-docs-theme/assets/sass/modules/typography.scss
@@ -146,3 +146,9 @@ h3.translations_head
    margin: 0;
    padding-left: 1.5rem;
 }
+
+/* details shortcode styling: add box round contents when open */
+details.synopsis[open]::details-content {
+  padding-left: 2em;
+  border: thin solid gray;
+}


### PR DESCRIPTION
Relates to dtdocs issue: #132 

In the processing module source code of each module, there is a call to `dt_iop_set_description` which sets the information shown in the tooltip when the module name is hovered over.

I have added this information to each module's page using a [Hugo _details_ shortcode](https://gohugo.io/shortcodes/details/).

* In the html it is presented as a collapsible `details` tag.
* In the PDF it is show in a box to make it clear it is to be read as grouped information.
* In the epub it is again shown as a collapsible details section.

I have added a note in the module overview trying to describe it.

I'm open to suggestions of how best to format it, and how best to describe it in the overview.

Some deprecated modules don't have a `dt_iop_set_description` call, but I have not specifically highlighted that (as people as less likely to be looking at the pages of deprecated modules anyway).
