### PR TITLE
Disable translated docs for Esperanto and Galician

### DIFF
--- a/disable-languages
+++ b/disable-languages
@@ -1,1 +1,1 @@
-zh_cn ja fi zh_Hant bg
+zh_cn ja fi zh_Hant bg eo gl


### PR DESCRIPTION
Both are basically empty. Esperanto is 7% translated, Galician 1%.
