### PR TITLE
Change the icons for expanding toc and tech info

### DIFF
--- a/themes/hugo-darktable-docs-theme/assets/sass/modules/body.scss
+++ b/themes/hugo-darktable-docs-theme/assets/sass/modules/body.scss
@@ -12,6 +12,10 @@ body, .card {
     }
 }
 
+a.toc {
+  text-decoration: none;
+}
+
 @include media-breakpoint-up(md) {
     .content {
 	top: 4rem;

--- a/themes/hugo-darktable-docs-theme/assets/sass/modules/typography.scss
+++ b/themes/hugo-darktable-docs-theme/assets/sass/modules/typography.scss
@@ -147,8 +147,61 @@ h3.translations_head
    padding-left: 1.5rem;
 }
 
+/* icon for opening table of contents */
+.toc {
+margin-bottom: 1em;
+}
+
+.toc-icon{
+list-style: none;
+    text-decoration: none;
+  &::before {
+    content: "+";
+    color: white;
+    background-color: black;
+    border-radius: 1em;
+    font-weight: bold;
+    padding-right: 5px;
+    padding-left: 5px;
+    padding: 0 5px;
+    margin-inline-start: 5px;
+    border: none;
+  }
+}
+
+.toc-icon[aria-expanded="true"]{
+list-style: none;
+  &::before {
+    content: "−";
+  }
+}
+
 /* details shortcode styling: add box round contents when open */
 details.technical-info[open]::details-content {
   padding-left: 2em;
-  border: thin solid gray;
+  border: 1px solid rgba(0, 0, 0, 0.125);
+}
+
+details.technical-info summary {
+  list-style: none;
+  &::before {
+    content: "+";
+    color: white;
+    background-color: black;
+    border-radius: 1em;
+    font-weight: bold;
+    padding: 0 5px;
+    margin-inline-start: 5px;
+  }
+}
+
+details.technical-info[open] summary {
+  list-style: none;
+  &::before {
+    content: "−";
+  }
+}
+
+details.technical-info summary::-webkit-details-marker {
+  display: none;
 }

--- a/themes/hugo-darktable-docs-theme/assets/sass/modules/typography.scss
+++ b/themes/hugo-darktable-docs-theme/assets/sass/modules/typography.scss
@@ -191,6 +191,7 @@ details.technical-info summary {
     border-radius: 1em;
     font-weight: bold;
     padding: 0 5px;
+    margin-right: 5px;
     margin-inline-start: 5px;
   }
 }

--- a/themes/hugo-darktable-docs-theme/layouts/partials/table-of-contents.html
+++ b/themes/hugo-darktable-docs-theme/layouts/partials/table-of-contents.html
@@ -1,4 +1,4 @@
-<a data-toggle="collapse" href="#collapseTOC" role="button" aria-expanded="false" aria-controls="collapseTOC">
+<a class="toc-icon toc" data-toggle="collapse" href="#collapseTOC" role="button" aria-expanded="false" aria-controls="collapseTOC">
   {{ i18n "table-of-contents" | default "Table of Contents" }}
 </a>
 <div class="collapse" id="collapseTOC">


### PR DESCRIPTION
Related to darktable issue #921 

Some changes to try to improve the readability of the expandable _table of contents_ and _technical info_ sections. This change would make them like this when closed:

<img width="226" height="195" alt="closed" src="https://github.com/user-attachments/assets/a915fb50-e218-46b1-b85d-8fd552c6f0cb" />

and like this when open:

<img width="510" height="701" alt="open" src="https://github.com/user-attachments/assets/4c0f9e17-be69-40f2-984b-649fbee4a5d7" />

I have not changed PDF (doesn't use TOC, doesn't have expandable technical details), nor the EPUB (doesn't use TOC).




