### PR TITLE
style: add blank lines inside technical-info detail blocks

### DIFF
--- a/content/module-reference/processing-modules/astrophoto-denoise.md
+++ b/content/module-reference/processing-modules/astrophoto-denoise.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : apply a poisson noise removal best suited for astrophotography.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : non-linear, Lab, display-referred
+
 {{< /details >}}
 
 Remove image noise while preserving structure. 

--- a/content/module-reference/processing-modules/base-curve.md
+++ b/content/module-reference/processing-modules/base-curve.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : apply a view transform based on personal or camera maker look, for corrective purposes, to prepare images for display.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : non-linear, RGB, display-referred
+
 {{< /details >}}
 
 Simulate the in-camera JPEG by applying a characteristic base curve to the image.

--- a/content/module-reference/processing-modules/basic-adjustments.md
+++ b/content/module-reference/processing-modules/basic-adjustments.md
@@ -7,6 +7,7 @@ weight: 20
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : apply usual image adjustments.
 
@@ -21,6 +22,7 @@ processing
 
 output
 : non-linear, RGB, scene-referred
+
 {{< /details >}}
 
 **Please note that this module is [deprecated](../../darkroom/processing-modules/deprecated.md) from darktable 3.6 and should no longer be used for new edits. Please use the [quick access panel](../../darkroom/organization/quick-access-panel.md) instead.**

--- a/content/module-reference/processing-modules/bloom.md
+++ b/content/module-reference/processing-modules/bloom.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : apply Orton effect for a dreamy ethereal look.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : non-linear, Lab, display-referred
+
 {{< /details >}}
 
 Create a soft bloom effect. 

--- a/content/module-reference/processing-modules/blurs.md
+++ b/content/module-reference/processing-modules/blurs.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : simulate physically-accurate lens and motion blurs.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : linear, RGB, scene-referred
+
 {{< /details >}}
 
 Simulate physically-accurate blurs in scene-referred RGB space.

--- a/content/module-reference/processing-modules/censorize.md
+++ b/content/module-reference/processing-modules/censorize.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : censorize license plates and body parts for privacy.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : special, RGB, scene-referred
+
 {{< /details >}}
 
 Degrade parts of the image in an aesthetically pleasing way, in order to anonymize people/objects or hide body parts.

--- a/content/module-reference/processing-modules/channel-mixer.md
+++ b/content/module-reference/processing-modules/channel-mixer.md
@@ -7,6 +7,7 @@ weight: 20
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : perform color space corrections such as white balance, channels mixing and conversions to monochrome emulating film.
 
@@ -21,6 +22,7 @@ processing
 
 output
 : linear, RGB, display-referred
+
 {{< /details >}}
 
 **Please note that this module is [deprecated](../../darkroom/processing-modules/deprecated.md) from darktable 3.4 and should no longer be used for new edits. Please use the [_color calibration_](./color-calibration.md) module instead.**

--- a/content/module-reference/processing-modules/chromatic-aberrations.md
+++ b/content/module-reference/processing-modules/chromatic-aberrations.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : correct chromatic aberrations.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : linear, RGB, scene-referred
+
 {{< /details >}}
 
 Correct chromatic aberrations.

--- a/content/module-reference/processing-modules/color-balance-rgb.md
+++ b/content/module-reference/processing-modules/color-balance-rgb.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : color grading tools using alpha masks to separate shadows, mid-tones and highlights.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : non-linear, RGB, scene-referred
+
 {{< /details >}}
 
 An advanced module which brings color-grading tools from cinematography into the photographic scene-referred pipeline.

--- a/content/module-reference/processing-modules/color-balance.md
+++ b/content/module-reference/processing-modules/color-balance.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : shift colors selectively by luminance range.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : non-linear, Lab, scene-referred
+
 {{< /details >}}
 
 A versatile tool for adjusting the image's color balance. 

--- a/content/module-reference/processing-modules/color-calibration.md
+++ b/content/module-reference/processing-modules/color-calibration.md
@@ -6,6 +6,7 @@ include_toc: true
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : perform color space corrections such as white balance, channels mixing and conversions to monochrome emulating film.
 
@@ -20,6 +21,7 @@ processing
 
 output
 : linear, RGB, scene-referred
+
 {{< /details >}}
 
 A fully-featured color-space correction, white balance adjustment and channel mixer module.

--- a/content/module-reference/processing-modules/color-contrast.md
+++ b/content/module-reference/processing-modules/color-contrast.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : increase saturation and separation between opposite colors.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : non-linear, Lab, display-referred
+
 {{< /details >}}
 
 A simplified control for changing the contrast or separation of colors between the green/magenta and blue/yellow axes in Lab color space. Higher values increase color contrast, lower values decrease it.

--- a/content/module-reference/processing-modules/color-correction.md
+++ b/content/module-reference/processing-modules/color-correction.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : correct white balance selectively for blacks and whites.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : non-linear, Lab, display-referred
+
 {{< /details >}}
 
 Modify the global image saturation to give the image a tint or as an alternative method to split-tone the image.

--- a/content/module-reference/processing-modules/color-equalizer.md
+++ b/content/module-reference/processing-modules/color-equalizer.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : change saturation, hue and brightness depending on local hue.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : quasi-linear, RGB, scene-referred
+
 {{< /details >}}
 
 Selectively adjust the hue, saturation, and/or brightness of pixels based on their current hue.

--- a/content/module-reference/processing-modules/color-harmonizer.md
+++ b/content/module-reference/processing-modules/color-harmonizer.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : harmonize colors toward a selected palette in perceptual space.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : linear, RGB, scene-referred
+
 {{< /details >}}
 
 The color harmonizer reduces chromatic dissonance by pushing hues toward a selected color palette.

--- a/content/module-reference/processing-modules/color-look-up-table.md
+++ b/content/module-reference/processing-modules/color-look-up-table.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : perform color space corrections and apply looks.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : linear or non-linear, Lab, display-referred
+
 {{< /details >}}
 
 A generic color look up table implemented in Lab space. 

--- a/content/module-reference/processing-modules/color-mapping.md
+++ b/content/module-reference/processing-modules/color-mapping.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : transfer a color palette and tonal repartition from one image to another.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : non-linear, Lab, display-referred
+
 {{< /details >}}
 
 Transfer the look and feel of one image to another. 

--- a/content/module-reference/processing-modules/color-reconstruction.md
+++ b/content/module-reference/processing-modules/color-reconstruction.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : recover clipped highlights by propagating surrounding colors.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : non-linear, Lab, display-referred
+
 {{< /details >}}
 
 Recover color information in blown-out highlights.

--- a/content/module-reference/processing-modules/color-zones.md
+++ b/content/module-reference/processing-modules/color-zones.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : selectively shift hues, chroma and lightness of pixels.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : non-linear, Lab, display-referred
+
 {{< /details >}}
 
 Selectively adjust the lightness, chroma and hue of pixels based on their current lightness, chroma and hue.

--- a/content/module-reference/processing-modules/colorize.md
+++ b/content/module-reference/processing-modules/colorize.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : overlay a solid color on the image.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : non-linear, Lab, display-referred
+
 {{< /details >}}
 
 Add a solid layer of color to the image.

--- a/content/module-reference/processing-modules/composite.md
+++ b/content/module-reference/processing-modules/composite.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : combine the image with elements from another processed image (move this module to after output color profile if you see banding).
 
@@ -19,6 +20,7 @@ processing
 
 output
 : linear, RGB, scene-referred
+
 {{< /details >}}
 
 Create a composite image by overlaying an already-processed image on top of the current image.

--- a/content/module-reference/processing-modules/contrast-brightness-saturation.md
+++ b/content/module-reference/processing-modules/contrast-brightness-saturation.md
@@ -7,6 +7,7 @@ weight: 20
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : adjust the look of the image.
 
@@ -21,6 +22,7 @@ processing
 
 output
 : non-linear, Lab, display-referred
+
 {{< /details >}}
 
 **Please note that this module is [deprecated](../../darkroom/processing-modules/deprecated.md) from darktable 4.4 and should no longer be used for new edits. Please use the [_color balance rgb_](./color-balance-rgb.md) module instead.**

--- a/content/module-reference/processing-modules/contrast-equalizer.md
+++ b/content/module-reference/processing-modules/contrast-equalizer.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : add or remove local contrast, sharpness, acutance.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : linear, Lab, scene-referred
+
 {{< /details >}}
 
 Adjust luminance and chroma contrast in the wavelet domain.

--- a/content/module-reference/processing-modules/crop-rotate.md
+++ b/content/module-reference/processing-modules/crop-rotate.md
@@ -7,6 +7,7 @@ weight: 20
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : change the framing and correct the perspective.
 
@@ -21,6 +22,7 @@ processing
 
 output
 : linear, RGB, scene-referred
+
 {{< /details >}}
 
 **Please note that this module is [deprecated](../../darkroom/processing-modules/deprecated.md) from darktable 3.8 and should no longer be used for new edits. Please use the [_crop_](./crop.md) module to crop the image, the [_rotate and perspective_](./rotate-perspective.md) module to perform rotation and keystone correction, and the [_orientation_](./orientation.md) module to flip the image on the horizontal/vertical axes.**

--- a/content/module-reference/processing-modules/crop.md
+++ b/content/module-reference/processing-modules/crop.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : change the framing.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : linear, RGB, scene-referred
+
 {{< /details >}}
 
 Crop an image using on-screen guides.

--- a/content/module-reference/processing-modules/defringe.md
+++ b/content/module-reference/processing-modules/defringe.md
@@ -7,6 +7,7 @@ weight: 20
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : attenuate chromatic aberration by desaturating edges.
 
@@ -21,6 +22,7 @@ processing
 
 output
 : non-linear, Lab, display-referred
+
 {{< /details >}}
 
 **Please note that this module is [deprecated](../../darkroom/processing-modules/deprecated.md) from darktable 3.6 and should no longer be used for new edits. Please use the [_chromatic aberrations_](./chromatic-aberrations.md) module instead.**

--- a/content/module-reference/processing-modules/demosaic.md
+++ b/content/module-reference/processing-modules/demosaic.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : reconstruct full RGB pixels from a sensor color filter array reading.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : linear, RGB, scene-referred
+
 {{< /details >}}
 
 Control how raw files are demosaiced and optionally apply capture sharpening.

--- a/content/module-reference/processing-modules/denoise-profiled.md
+++ b/content/module-reference/processing-modules/denoise-profiled.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : denoise using noise statistics profiled on sensors.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : linear, RGB, scene-referred
+
 {{< /details >}}
 
 An easy to use and highly efficient denoise module, adapted to the individual noise profiles of a wide range of camera sensors.

--- a/content/module-reference/processing-modules/diffuse.md
+++ b/content/module-reference/processing-modules/diffuse.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : simulate directional diffusion of light with heat transfer model to apply an iterative edge-oriented blur, inpaint damaged parts of the image, or to remove blur with blind deconvolution.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : linear, RGB, scene-referred
+
 {{< /details >}}
 
 Diffusion is a family of physical processes by which particles move and spread gradually with time, from a source that generates them. In image processing, diffusion mostly occurs in two places:

--- a/content/module-reference/processing-modules/dither-or-posterize.md
+++ b/content/module-reference/processing-modules/dither-or-posterize.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : reduce banding and posterization effects in output JPEGs by adding random noise, or reduce bit depth.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : non-linear, RGB, display-referred
+
 {{< /details >}}
 
 This module eliminates some of the banding artifacts that can result when darktable's internal 32-bit floating point data is transferred into discrete 8-bit or 16-bit integer output format for display or export. It can also be used for creative posterization effects.

--- a/content/module-reference/processing-modules/enlarge-canvas.md
+++ b/content/module-reference/processing-modules/enlarge-canvas.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : add empty space to the left, top, right or bottom.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : linear, RGB, scene-referred
+
 {{< /details >}}
 
 Increase the size of the image canvas and fill the additional area with the selected color.

--- a/content/module-reference/processing-modules/exposure.md
+++ b/content/module-reference/processing-modules/exposure.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : redo the exposure of the shot as if you were still in-camera using a color-safe brightening similar to increasing ISO setting.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : linear, RGB, scene-referred
+
 {{< /details >}}
 
 Increase or decrease the overall brightness of an image.

--- a/content/module-reference/processing-modules/external-raster.md
+++ b/content/module-reference/processing-modules/external-raster.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : read PFM/PNG files recorded for use as raster masks.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : linear, raw, scene-referred
+
 {{< /details >}}
 
 Generate a raster mask from a `.pfm` to be used by subsequent processing modules.

--- a/content/module-reference/processing-modules/filmic-rgb.md
+++ b/content/module-reference/processing-modules/filmic-rgb.md
@@ -6,6 +6,7 @@ include_toc: true
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : apply a view transform to prepare the scene-referred pipeline for display on SDR screens and paper prints while preventing clipping in non-destructive ways.
 
@@ -20,6 +21,7 @@ processing
 
 output
 : non-linear, RGB, display-referred
+
 {{< /details >}}
 
 Remap the tonal range of an image by reproducing the tone and color response of classic film.

--- a/content/module-reference/processing-modules/framing.md
+++ b/content/module-reference/processing-modules/framing.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : add solid borders or margins around the image.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : linear or non-linear, RGB, display-referred
+
 {{< /details >}}
 
 Generate a frame around the image. 

--- a/content/module-reference/processing-modules/graduated-density.md
+++ b/content/module-reference/processing-modules/graduated-density.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : simulate an optical graduated neutral density filter.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : non-linear, RGB, display-referred
+
 {{< /details >}}
 
 Simulate a graduated density filter in order to correct exposure and color in a progressive manner.

--- a/content/module-reference/processing-modules/grain.md
+++ b/content/module-reference/processing-modules/grain.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : simulate silver grains from film.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : non-linear, Lab, display-referred
+
 {{< /details >}}
 
 Simulate the grain of analog film. The grain is processed on the L channel of Lab color space.

--- a/content/module-reference/processing-modules/haze-removal.md
+++ b/content/module-reference/processing-modules/haze-removal.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : remove fog and atmospheric hazing from images.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : linear, RGB, scene-referred
+
 {{< /details >}}
 
 Automatically reduce the effect of dust and haze in the atmosphere. This module may also be employed more generally to give images a color boost specifically in low-contrast regions of the image.

--- a/content/module-reference/processing-modules/highlight-reconstruction.md
+++ b/content/module-reference/processing-modules/highlight-reconstruction.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : avoid magenta highlights and try to recover highlights colors.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : linear, raw, scene-referred
+
 {{< /details >}}
 
 Attempt to reconstruct color information for pixels that are clipped in one or more RGB channel.

--- a/content/module-reference/processing-modules/highpass.md
+++ b/content/module-reference/processing-modules/highpass.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : isolate high frequencies in the image.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : special, Lab, scene-referred
+
 {{< /details >}}
 
 A high pass filter. 

--- a/content/module-reference/processing-modules/hot-pixels.md
+++ b/content/module-reference/processing-modules/hot-pixels.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : remove abnormally bright pixels by dampening them with neighbors.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : linear, raw, scene-referred
+
 {{< /details >}}
 
 Automatically detect and eliminate hot pixels. 

--- a/content/module-reference/processing-modules/input-color-profile.md
+++ b/content/module-reference/processing-modules/input-color-profile.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : convert any RGB input to pipeline reference RGB using color profiles to remap RGB values.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : linear, RGB, scene-referred
+
 {{< /details >}}
 
 Define how darktable will interpret the colors of the image. 

--- a/content/module-reference/processing-modules/invert.md
+++ b/content/module-reference/processing-modules/invert.md
@@ -7,6 +7,7 @@ weight: 20
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : invert film negatives.
 
@@ -21,6 +22,7 @@ processing
 
 output
 : linear, raw, display-referred
+
 {{< /details >}}
 
 **Please note that this module is [deprecated](../../darkroom/processing-modules/deprecated.md) from darktable 3.4 and should no longer be used for new edits. Please use the [_negadoctor_](./negadoctor.md) module instead.**

--- a/content/module-reference/processing-modules/lens-correction.md
+++ b/content/module-reference/processing-modules/lens-correction.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : correct lenses optical flaws.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : linear, RGB, scene-referred
+
 {{< /details >}}
 
 Automatically correct for (or simulate) lens distortion, transverse chromatic aberrations (TCA) and vignetting.

--- a/content/module-reference/processing-modules/levels.md
+++ b/content/module-reference/processing-modules/levels.md
@@ -7,6 +7,7 @@ weight: 20
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : adjust black, white and mid-gray points.
 
@@ -21,6 +22,7 @@ processing
 
 output
 : non-linear, Lab, display-referred
+
 {{< /details >}}
 
 **Please note that this module is [deprecated](../../darkroom/processing-modules/deprecated.md) from darktable 4.4 and should no longer be used for new edits. Please use the [_rgb levels_](./rgb-levels.md) module instead.**

--- a/content/module-reference/processing-modules/liquify.md
+++ b/content/module-reference/processing-modules/liquify.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : distort parts of the image.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : linear, RGB, scene-referred
+
 {{< /details >}}
 
 Move pixels around by applying freestyle distortions to parts of the image using points, lines and curves.

--- a/content/module-reference/processing-modules/local-contrast.md
+++ b/content/module-reference/processing-modules/local-contrast.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : manipulate local and global contrast separately.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : non-linear, Lab, display-referred
+
 {{< /details >}}
 
 Enhance the image's local contrast.

--- a/content/module-reference/processing-modules/lowlight-vision.md
+++ b/content/module-reference/processing-modules/lowlight-vision.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : simulate human night vision.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : non-linear, Lab, display-referred
+
 {{< /details >}}
 
 Simulate human lowlight vision. This module can also be used to perform a day-to-night conversion.

--- a/content/module-reference/processing-modules/lowpass.md
+++ b/content/module-reference/processing-modules/lowpass.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : isolate low frequencies in the image.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : special, Lab, scene-referred
+
 {{< /details >}}
 
 Apply a low pass filter (for example, a Gaussian blur) to the image, while controlling the output contrast and saturation. 

--- a/content/module-reference/processing-modules/lut-3D.md
+++ b/content/module-reference/processing-modules/lut-3D.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : perform color space corrections and apply look.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : linear or non-linear, RGB, display-referred
+
 {{< /details >}}
 
 Transform RGB values with a 3D LUT file.

--- a/content/module-reference/processing-modules/monochrome.md
+++ b/content/module-reference/processing-modules/monochrome.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : quickly convert an image to black & white using a variable color filter.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : non-linear, Lab, display-referred
+
 {{< /details >}}
 
 Quickly convert an image to black & white using a variable color filter.

--- a/content/module-reference/processing-modules/negadoctor.md
+++ b/content/module-reference/processing-modules/negadoctor.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : invert film negative scans and simulate printing on paper.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : non-linear, RGB, display-referred
+
 {{< /details >}}
 
 Process scanned film negatives. 

--- a/content/module-reference/processing-modules/orientation.md
+++ b/content/module-reference/processing-modules/orientation.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : flip or rotate image by step of 90 degrees.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : linear, RGB, scene-referred
+
 {{< /details >}}
 
 Rotate the image 90 degrees at a time or flip the image horizontally and/or vertically.

--- a/content/module-reference/processing-modules/output-color-profile.md
+++ b/content/module-reference/processing-modules/output-color-profile.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : convert pipeline reference RGB to any display RGB using color profiles to remap RGB values.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : non-linear, RGB or Lab, display-referred
+
 {{< /details >}}
 
 Manage the output profile for export and the rendering intent to be used when mapping between color spaces.

--- a/content/module-reference/processing-modules/raw-black-white-point.md
+++ b/content/module-reference/processing-modules/raw-black-white-point.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : sets technical specificities of the raw sensor  touch with great care!.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : linear, raw, scene-referred
+
 {{< /details >}}
 
 Define camera-specific black and white points. 

--- a/content/module-reference/processing-modules/raw-chromatic-aberrations.md
+++ b/content/module-reference/processing-modules/raw-chromatic-aberrations.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : correct chromatic aberrations for Bayer sensors.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : linear, raw, scene-referred
+
 {{< /details >}}
 
 Correct chromatic aberrations of raw images.

--- a/content/module-reference/processing-modules/raw-denoise.md
+++ b/content/module-reference/processing-modules/raw-denoise.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : denoise the raw image early in the pipeline.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : linear, raw, scene-referred
+
 {{< /details >}}
 
 Perform denoising on raw image data before it is [demosaiced](./demosaic.md). 

--- a/content/module-reference/processing-modules/retouch.md
+++ b/content/module-reference/processing-modules/retouch.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : remove and clone spots, perform split-frequency skin editing.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : linear, RGB, scene-referred
+
 {{< /details >}}
 
 Remove unwanted elements from your image by cloning, healing, blurring and filling using drawn shapes.

--- a/content/module-reference/processing-modules/rgb-curve.md
+++ b/content/module-reference/processing-modules/rgb-curve.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : alter an image’s tones using curves in RGB color space.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : linear, RGB, display-referred
+
 {{< /details >}}
 
 A classic digital photography tool to alter an image's tones using curves.

--- a/content/module-reference/processing-modules/rgb-levels.md
+++ b/content/module-reference/processing-modules/rgb-levels.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : adjust black, white and mid-gray points in RGB color space.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : non-linear, RGB, display-referred
+
 {{< /details >}}
 
 Adjust black, white and mid-gray points in RGB color space. This module is similar to the [_levels_](./levels.md) module, which works in Lab color space.

--- a/content/module-reference/processing-modules/rgb-primaries.md
+++ b/content/module-reference/processing-modules/rgb-primaries.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : adjustment of the RGB color primaries for color grading.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : linear, RGB, scene-referred
+
 {{< /details >}}
 
 Adjust the hue and [purity](../../special-topics/color-management/color-dimensions.md#definitions) of the RGB primary colors (i.e. _which_ red, green and blue they represent), while leaving uncolored (gray) pixels unchanged. In addition to preserving gray pixels, the opponency relationships between the colors are also preserved under this adjustment: If you increase the purity of the blue primary, the opponent yellow's intensity increases to balance things out; If you twist the blue hue toward cyan, the opponent yellow is twisted toward orange.

--- a/content/module-reference/processing-modules/rotate-perspective.md
+++ b/content/module-reference/processing-modules/rotate-perspective.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : rotate or distort perspective.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : linear, RGB, scene-referred
+
 {{< /details >}}
 
 Automatically correct for converging lines, a form of perspective distortion. The underlying mechanism is inspired by Markus Hebel's [_ShiftN_](http://www.shiftn.de/) program. This module also allows for the rotation of the image to be adjusted.

--- a/content/module-reference/processing-modules/rotate-pixels.md
+++ b/content/module-reference/processing-modules/rotate-pixels.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : null
 
@@ -19,6 +20,7 @@ processing
 
 output
 : null
+
 {{< /details >}}
 
 The sensors of some cameras (such as the Fujifilm FinePix S2Pro, F700, and E550) have a diagonally oriented Bayer pattern instead of the usual orthogonal layout.

--- a/content/module-reference/processing-modules/scale-pixels.md
+++ b/content/module-reference/processing-modules/scale-pixels.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : module for setting pixel aspect ratio  useful for certain sensor types and anamorphic desqueeze.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : linear, RGB, scene-referred
+
 {{< /details >}}
 
 Some cameras (such as the Nikon D1X) have rectangular instead of the usual square sensor cells. Without correction this would lead to distorted images. This module applies the required scaling.

--- a/content/module-reference/processing-modules/shadows-and-highlights.md
+++ b/content/module-reference/processing-modules/shadows-and-highlights.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : modify the tonal range of the shadows and highlights of an image by enhancing local contrast.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : non-linear, Lab, display-referred
+
 {{< /details >}}
 
 Modify the tonal range of the shadows and highlights of an image by enhancing local contrast.

--- a/content/module-reference/processing-modules/sharpen.md
+++ b/content/module-reference/processing-modules/sharpen.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : sharpen the details in the image using a standard UnSharp Mask (USM).
 
@@ -19,6 +20,7 @@ processing
 
 output
 : quasi-linear, Lab, display or scene-referred
+
 {{< /details >}}
 
 Sharpen the details in the image using a standard UnSharp Mask (USM). 

--- a/content/module-reference/processing-modules/sigmoid.md
+++ b/content/module-reference/processing-modules/sigmoid.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : apply a view transform to make an image displayable on a screen or print using a robust and smooth tone curve with optional color preservation methods.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : linear, RGB, display-referred
+
 {{< /details >}}
 
 Remap the tonal range of an image using a modified generalized log-logistic curve.

--- a/content/module-reference/processing-modules/soften.md
+++ b/content/module-reference/processing-modules/soften.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : create a softened image using the Orton effect.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : linear, RGB, display-referred
+
 {{< /details >}}
 
 Create a softened image using the [Orton effect](https://en.wikipedia.org/wiki/Orton_(photography)).

--- a/content/module-reference/processing-modules/split-toning.md
+++ b/content/module-reference/processing-modules/split-toning.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : use two specific colors for shadows and highlights and create a linear toning effect between them up to a pivot.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : linear, RGB, scene-referred
+
 {{< /details >}}
 
 Create a two color linear toning effect where the shadows and highlights are represented by two different colors.

--- a/content/module-reference/processing-modules/spot-removal.md
+++ b/content/module-reference/processing-modules/spot-removal.md
@@ -7,6 +7,7 @@ weight: 20
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : remove sensor dust spots.
 
@@ -21,6 +22,7 @@ processing
 
 output
 : linear, RGB, scene-referred
+
 {{< /details >}}
 
 **Please note that this module is [deprecated](../../darkroom/processing-modules/deprecated.md) from darktable 3.6 and should no longer be used for new edits. Please use the "cloning" tool in the [_retouch_](./retouch.md) module instead.**

--- a/content/module-reference/processing-modules/surface-blur.md
+++ b/content/module-reference/processing-modules/surface-blur.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : apply edge-aware surface blur to denoise or smoothen textures.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : linear, RGB, scene-referred
+
 {{< /details >}}
 
 Smooth image surfaces while preserving sharp edges using a bilateral filter. 

--- a/content/module-reference/processing-modules/tone-curve.md
+++ b/content/module-reference/processing-modules/tone-curve.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : alter an image’s tones using curves.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : non-linear, Lab, display-referred
+
 {{< /details >}}
 
 A classic digital photography tool to alter the tones of an image's using curves.

--- a/content/module-reference/processing-modules/tone-equalizer.md
+++ b/content/module-reference/processing-modules/tone-equalizer.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : relight the scene as if the lighting was done directly on the scene.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : quasi-linear, RGB, scene-referred
+
 {{< /details >}}
 
 Dodge and burn while preserving local contrast.

--- a/content/module-reference/processing-modules/unbreak-input-profile.md
+++ b/content/module-reference/processing-modules/unbreak-input-profile.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : correct input color profiles meant to be applied on non-linear RGB.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : non-linear, RGB, display-referred
+
 {{< /details >}}
 
 Add a correction curve to image data. This is required if you have selected certain input profiles in the [_input color profile_](./input-color-profile.md) module.

--- a/content/module-reference/processing-modules/velvia.md
+++ b/content/module-reference/processing-modules/velvia.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : resaturate giving more weight to blacks, whites and low-saturation pixels.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : linear, RGB, scene-referred
+
 {{< /details >}}
 
 Resaturate pixels in a weighted manner that gives more weight to blacks, whites and less saturated pixels. 

--- a/content/module-reference/processing-modules/vibrance.md
+++ b/content/module-reference/processing-modules/vibrance.md
@@ -7,6 +7,7 @@ weight: 20
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : saturate and reduce the lightness of the most saturated pixels to make the colors more vivid.
 
@@ -21,6 +22,7 @@ processing
 
 output
 : non-linear, Lab, display-referred
+
 {{< /details >}}
 
 **Please note that this module is [deprecated](../../darkroom/processing-modules/deprecated.md) from darktable 3.6 and should no longer be used for new edits. Please use the vibrance control in the [_color balance rgb_](./color-balance-rgb.md) module instead.**

--- a/content/module-reference/processing-modules/vignetting.md
+++ b/content/module-reference/processing-modules/vignetting.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : simulate a lens fall-off close to edges.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : non-linear, RGB, display-referred
+
 {{< /details >}}
 
 Apply a vignetting effect to the image. 

--- a/content/module-reference/processing-modules/watermark.md
+++ b/content/module-reference/processing-modules/watermark.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : overlay an SVG watermark like a signature on the image.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : non-linear, RGB, display-referred
+
 {{< /details >}}
 
 Render a vector-based overlay onto your image. Watermarks are standard SVG documents and can be designed using [Inkscape](http://www.inkscape.org/).

--- a/content/module-reference/processing-modules/white-balance.md
+++ b/content/module-reference/processing-modules/white-balance.md
@@ -5,6 +5,7 @@ weight: 10
 ---
 
 {{< details summary="Technical information" class="technical-info" >}}
+
 description
 : scale raw RGB channels to balance white and help demosaicing.
 
@@ -19,6 +20,7 @@ processing
 
 output
 : linear, raw, scene-referred
+
 {{< /details >}}
 
 Adjust the white balance of the image by altering the temperature and tint, defining a coefficient for each RGB channel, or choosing from list of predefined white balance settings.


### PR DESCRIPTION
Added a blank line after the opening tag and before the closing tag in all processing-module technical information blocks. This excludes the blocks from translation by the Weblate i18n tooling.

@Phemisters please take note of this change; it is necessary to make automated translations of the tech-blocks easier. Currently the opening and closing tags were included in the translatable strings which was a) poentially confusing and b) makes automating translating these strings harder. As this will not break anything I will merge this right away. 
