### PR TITLE
update lua documentation to reflect bundling

### DIFF
--- a/content/lua/basic-principles.md
+++ b/content/lua/basic-principles.md
@@ -4,7 +4,7 @@ id: basic-principles
 weight: 20
 ---
 
-At startup, darktable will automatically run the Lua scripts `$DARKTABLE/share/darktable/luarc` (where `$DARKTABLE` represents the darktable installation directory) and `luarc` in the darktable [configuration directory](../preferences-settings/config-directory.md).
+At startup, darktable will automatically run the Lua scripts `$DARKTABLE/share/darktable/luarc` (where `$DARKTABLE` represents the darktable installation directory) and `luarc` in the darktable [configuration directory](../preferences-settings/config-directory.md). Starting from 5.6 `luarc` is not strictly required but will be respected if present. 
 
 This is the only time darktable will run Lua scripts by itself and can be used to load other scripts (like the script manager). These scripts can register callbacks to perform actions on various darktable events. This callback mechanism is the primary method of triggering lua actions. 
 

--- a/content/lua/basic-principles.md
+++ b/content/lua/basic-principles.md
@@ -8,6 +8,8 @@ At startup, darktable will automatically run the Lua scripts `$DARKTABLE/share/d
 
 This is the only time darktable will run Lua scripts by itself and can be used to load other scripts (like the script manager). These scripts can register callbacks to perform actions on various darktable events. This callback mechanism is the primary method of triggering lua actions. 
 
+The loading of lua scripts on startup can be disabled in [preferences/lua options](../preferenes-settings/lua-options.md).
+
 ### Keeping things tidy
 
 If you want to add your own scripts to darktable you could simply write their entirety into luarc. To keep things tidy you could consider saving your script inside of darktable's configuration directory to e.g. `lua/user/user-script.lua` and tell darktable to load it by adding `require "user/user-script.lua"` to luarc. If you are using the script-manager (which you likely are if you follow the guide to install the pre-existing scripts) you will then have to activate the script in the scripts utility module by changing the folder to "user" and clicking the on/off button next to the corresponding script. 

--- a/content/lua/basic-principles.md
+++ b/content/lua/basic-principles.md
@@ -6,6 +6,8 @@ weight: 20
 
 At startup, darktable will automatically run the Lua scripts `$DARKTABLE/share/darktable/luarc` (where `$DARKTABLE` represents the darktable installation directory) and `luarc` in the darktable [configuration directory](../preferences-settings/config-directory.md). Starting from 5.6 `luarc` is not strictly required but will be respected if present. 
 
+If the user installs the lua-scripts locally then those are executed instead of the bundled ones.
+
 This is the only time darktable will run Lua scripts by itself and can be used to load other scripts (like the script manager). These scripts can register callbacks to perform actions on various darktable events. This callback mechanism is the primary method of triggering lua actions. 
 
 The loading of lua scripts on startup can be disabled in [preferences/lua options](../preferenes-settings/lua-options.md).

--- a/content/lua/installation.md
+++ b/content/lua/installation.md
@@ -1,14 +1,20 @@
 ---
-title: installing pre-existing scripts
+title: pre-existing scripts
 id: installation
 weight: 15
 ---
 
 ## Download and Install
 
-A collection of scripts is available in the [lua-scripts repository](https://github.com/darktable-org/lua-scripts). This also includes the script manager, which makes it easier to enable or disable individual scripts from the GUI. To use these existing scripts, they must be installed in darktable. This can in most cases be done within darktable's GUI, but depends on your OS and chosen method of installation. 
+A collection of scripts is available in the [lua-scripts repository](https://github.com/darktable-org/lua-scripts). This also includes the script manager, which makes it easier to enable or disable individual scripts from the GUI. Documentation for these lua scripts is included in the [lua docs](https://docs.darktable.org/lua/stable/lua.scripts.manual/scripts/).
+
+Starting with darktable 5.6, the lua-scripts are included with the release, so they no longer have to installed separately. If the lua-scripts are already installed, the installed version will be used instead of the bundled version.
+
+To use these existing scripts in versions before 5.6, they must be installed in darktable. This can in most cases be done within darktable's GUI, but depends on your OS and chosen method of installation. 
 
 In any case, darktable should be started at least once to set up its directories. The config directories for most installation types are listed on the [configuration directory](../preferences-settings/config-directory.md) page.
+
+If you don’t want any lua scripts running they can be disabled in Preferences->Lua options.
 
 ### Linux Package, AppImage and Flatpak
 

--- a/content/lua/installation.md
+++ b/content/lua/installation.md
@@ -14,7 +14,7 @@ To use these existing scripts in versions before 5.6, they must be installed in 
 
 In any case, darktable should be started at least once to set up its directories. The config directories for most installation types are listed on the [configuration directory](../preferences-settings/config-directory.md) page.
 
-If you don’t want any lua scripts running they can be disabled in Preferences->Lua options.
+If you don’t want any lua scripts running they can be disabled in [preferences/lua options](../preferenes-settings/lua-options.md).
 
 ### Linux Package, AppImage and Flatpak
 

--- a/content/preferences-settings/lua-options.md
+++ b/content/preferences-settings/lua-options.md
@@ -4,7 +4,7 @@ id: lua-options
 weight: 140
 ---
 
-Pre 5.6 these set up the behavior of the [Lua scripts installer](../module-reference/utility-modules/lighttable/lua-scripts-installer.md).
+__Pre 5.6__ these set up the behavior of the [Lua scripts installer](../module-reference/utility-modules/lighttable/lua-scripts-installer.md).
 
 lua scripts installer log debug messages
 : Write debugging messages to the log if the -d lua flag is specified
@@ -12,10 +12,10 @@ lua scripts installer log debug messages
 lua scripts installer don't show again
 : Check this box to hide the Lua scripts installer in the lighttable if no lua scripts are installed.
 
-From 5.6 onward these settings control how the bundled lua scripts are handled. 
+From __5.6 onward__ these settings control how lua scripts are handled. 
 
 check for updated lua scripts on start up
-: automatically update scripts to current version
+: automatically update (bundled) scripts to current version
 
 disable lua scripts
-: do not run the lua scripts
+: do not run lua scripts (both bundled and user defined)

--- a/content/preferences-settings/lua-options.md
+++ b/content/preferences-settings/lua-options.md
@@ -4,10 +4,18 @@ id: lua-options
 weight: 140
 ---
 
-Control the behavior of the [Lua scripts installer](../module-reference/utility-modules/lighttable/lua-scripts-installer.md).
+Pre 5.6 these set up the behavior of the [Lua scripts installer](../module-reference/utility-modules/lighttable/lua-scripts-installer.md).
 
 lua scripts installer log debug messages
 : Write debugging messages to the log if the -d lua flag is specified
 
 lua scripts installer don't show again
 : Check this box to hide the Lua scripts installer in the lighttable if no lua scripts are installed.
+
+From 5.6 onward these settings control how the bundled lua scripts are handled. 
+
+check for updated lua scripts on start up
+: automatically update scripts to current version
+
+disable lua scripts
+: do not run the lua scripts


### PR DESCRIPTION
Adresses https://github.com/darktable-org/dtdocs/issues/908 as starting from 5.6 lua scripts are delivered bundled with darktable. 

See also https://discuss.pixls.us/t/darktable-5-6-lua-scripts/58755 .

@wpferguson could you clarify whether the preference "disable lua scripts" disables ALL lua scripts including ones that might be specified in the now optional `luarc` or just the bundled ones?