### PR TITLE
Update exposure.md to include highlight preservation mode

### DIFF
--- a/content/module-reference/processing-modules/exposure.md
+++ b/content/module-reference/processing-modules/exposure.md
@@ -41,6 +41,9 @@ mode
 compensate camera exposure (manual mode)
 : Automatically remove the camera exposure bias (taken from the image's Exif data).
 
+highlight preservation mode (manual mode)
+: Some cameras underexpose the raw file in specific modes such as HDR, dynamic range expansion or HLG to protect the highlights. When enabled, it restores the withheld exposure (the amount, in EV, is shown on the button). This control appears only when such a mode is detected in the image's Exif data.
+
 exposure (manual mode)
 : Increase (move to the right) or decrease (move to the left) the exposure value (EV). To adjust by more than the default limits shown on the slider, right click and enter the desired value up to +/-18 EV (see [module controls](../../darkroom/processing-modules/module-controls.md)).
 : The [picker](../../darkroom/processing-modules/module-controls.md#pickers) tool on the right sets the exposure such that the average of the selected region matches the target lightness defined in [area exposure mapping](#area-exposure-mapping) options.


### PR DESCRIPTION
adresses https://github.com/darktable-org/dtdocs/issues/943

For internal documentation: The mode is activated upon import by the function `_check_highlight_preservation` in [exif.cc](https://github.com/darktable-org/darktable/blob/master/src/common/exif.cc). In the code there the affected camera models, modes and exif tags are documented. 

@Phemisters do you think we should make this more verbose to include technical information on what cameras, modes and exif tags are relevant? 