### PR TITLE
Some further updates to the lua docs

### DIFF
--- a/content/lua/basic-principles.md
+++ b/content/lua/basic-principles.md
@@ -4,21 +4,37 @@ id: basic-principles
 weight: 20
 ---
 
-The central orchestrator for lua scripts is the __script manager__, which spawns the utility module __scripts__ in the lighttable. 
-
-In previous versions of darktable this had to be installed manually (see [darktables scripts](darktables-scripts.md)). If darktable detects `lua/tools/script_manager.lua` (e.g. from a previous version) within darktable's [configuration directory](../preferences-settings/config-directory.md) it will run the script manager in the config-directory instead of the bundled one. 
-
 Scripts can register callbacks to perform actions on various darktable events. This callback mechanism is the primary method of triggering lua actions. 
 
-The loading of the bundled lua scripts on startup can be disabled in [preferences/lua options](../preferences-settings/lua-options.md).
+The central orchestrator for lua scripts is the _script manager_, which spawns the utility module __scripts__ in the lighttable and loads darktable's bundled scripts. 
 
-### Adding your own scripts
+Lua scripts can be disabled in [preferences/lua options](../preferences-settings/lua-options.md).
 
-The script manager will automatically check for Lua scripts present in `lua/` within the [configuration directory](../preferences-settings/config-directory.md). If e.g. a custom script is present as `lua/user/userscript.lua` the script manager will pick it up and it will be available through the scripts module in the lighttable. 
+### how darktable loads scripts (and the script manager)
 
-If you are using the script-manager (which you likely are) you will then have to activate added scripts in the scripts utility module by selecting the appropriate folder and clicking the on/off button next to the corresponding script. 
+darktable treats two kinds of location differently: Files that are _executed_ as Lua code, and directories that are _scanned_ for scripts:
 
-At startup, darktable will also automatically run the Lua scripts `$DARKTABLE/share/darktable/luarc` (where `$DARKTABLE` represents the darktable installation directory) and `luarc` in the darktable [configuration directory](../preferences-settings/config-directory.md). 
+* Executed at startup:
+    * `$DARKTABLE/share/darktable/luarc`: run by darktable itself. This is the entry point that launches the script manager. It serves internal purposes only and should not be edited. $DARKTABLE is the programms installation directory.
+    * `\[configuration-directory]/luarc`: run by the script manager, if present. This is one way of running your own scripts (see below).
+* Scanned for `.lua` scripts (which then appear in the scripts-module):
+    * `$DARKTABLE/share/darktable/lua-scripts/`: darktable's bundled scripts.
+    * `[configuration-directory]/lua/\[folder]/`: your own scripts (see below).
 
-If you want you could also write your scripts entirety into `luarc` (which is not very convenient). If you dont want to use or rely on the script manager you can also tell darktable to load a script by including it in one of the two `luarc` files (e.g. a script present in the config directory in `lua/user/user-script` could be loaded by adding `require "user/user-script"` to `luarc`. 
+The [configuration directory](../preferences-settings/config-directory.md) is specific to your OS. 
 
+Thus you can __add your own scripts__ as follows:
+* Have the scripts-module pick them up: (recommended)
+    * Place your script e.g. in `[configuration-directory]/lua/user/myscript.lua`
+    * Activate it in the scripts-module by selecting the appropriate folder (in this example "user") and clicking the on/off button next to the corresponding script. 
+    * Note: For the scripts-module to pick up scripts they will need to be in a _subfolder_ of `configuration-directory/lua`.
+* using `luarc` (runs at startup automatically)
+    * Either write the code directly into `\[configuration-directory]/luarc`. This works, but is not tidy for anything beyond a few lines. The code runs at startup.
+    * Or keep the code in its own file and `require` through `luarc`: E.g. a script present in `[configuration-directory]/lua/userscript.lua` could be loaded by adding `require "userscript"` (note that .lua is omitted here).
+
+
+### a note on lua-scripts installations from previous darktable versions
+
+In previous versions of darktable this had to be installed manually (see [darktable's scripts](darktables-scripts.md)). 
+
+To remain compatible with such an installation, `require` looks for a script manager in your configuration directory before loading the bundled one: if `[configuration-directory]/lua/tools/script_manager.lua` is present (for example from a manual pre-5.6 installation), _that_ script manager is run instead of the bundled one. In this case the luarc file in the configuration directory is not loaded. 

--- a/content/lua/basic-principles.md
+++ b/content/lua/basic-principles.md
@@ -29,12 +29,12 @@ Thus you can __add your own scripts__ as follows:
     * Activate it in the scripts-module by selecting the appropriate folder (in this example "user") and clicking the on/off button next to the corresponding script. 
     * Note: For the scripts-module to pick up scripts they will need to be in a _subfolder_ of `configuration-directory/lua`.
 * Use `luarc` (runs at startup automatically)
-    * Either write the code directly into `[configuration-directory]/luarc`. This works, but is not tidy for anything beyond a few lines. 
+    * Either write the code directly into `[configuration-directory]/luarc`. This works, but is not practical for anything beyond a few lines. 
     * Or keep the code in its own file and `require` through `luarc`: E.g. a script present in `[configuration-directory]/lua/userscript.lua` could be loaded by adding `require "userscript"` (note that .lua is omitted here).
 
 
 ### a note on lua-scripts installations from previous darktable versions
 
-In previous versions of darktable this had to be installed manually (see [darktable's scripts](darktables-scripts.md)). 
+Before version 5.6 darktable's scripts had to be installed manually (see [darktable's scripts](darktables-scripts.md)). 
 
 To remain compatible with such an installation, `require` looks for a script manager in your configuration directory before loading the bundled one: if `[configuration-directory]/lua/tools/script_manager.lua` is present (for example from a manual pre-5.6 installation), _that_ script manager is run instead of the bundled one. In this case the luarc file in the configuration directory is not loaded. 

--- a/content/lua/basic-principles.md
+++ b/content/lua/basic-principles.md
@@ -1,17 +1,24 @@
 ---
-title: "basic principles: luarc files"
+title: "basic principles"
 id: basic-principles
 weight: 20
 ---
 
-At startup, darktable will automatically run the Lua scripts `$DARKTABLE/share/darktable/luarc` (where `$DARKTABLE` represents the darktable installation directory) and `luarc` in the darktable [configuration directory](../preferences-settings/config-directory.md). Starting from 5.6 `luarc` is not strictly required but will be respected if present. 
+The central orchestrator for lua scripts is the __script manager__, which spawns the utility module __scripts__ in the lighttable. 
 
-If the user installs the lua-scripts locally then those are executed instead of the bundled ones.
+In previous versions of darktable this had to be installed manually (see [darktables scripts](darktables-scripts.md)). If darktable detects `lua/tools/script-manager.lua` (e.g. from a previous version) within darktable's [configuration directory](../preferences-settings/config-directory.md) it will run the script manager in the config-directory instead of the bundled one. 
 
-This is the only time darktable will run Lua scripts by itself and can be used to load other scripts (like the script manager). These scripts can register callbacks to perform actions on various darktable events. This callback mechanism is the primary method of triggering lua actions. 
+Scripts can register callbacks to perform actions on various darktable events. This callback mechanism is the primary method of triggering lua actions. 
 
-The loading of lua scripts on startup can be disabled in [preferences/lua options](../preferences-settings/lua-options.md).
+The loading of the bundled lua scripts on startup can be disabled in [preferences/lua options](../preferences-settings/lua-options.md).
 
-### Keeping things tidy
+### Adding your own scripts
 
-If you want to add your own scripts to darktable you could simply write their entirety into luarc. To keep things tidy you could consider saving your script inside of darktable's configuration directory to e.g. `lua/user/user-script.lua` and tell darktable to load it by adding `require "user/user-script.lua"` to luarc. If you are using the script-manager (which you likely are if you follow the guide to install the pre-existing scripts) you will then have to activate the script in the scripts utility module by changing the folder to "user" and clicking the on/off button next to the corresponding script. 
+The script manager will automatically check for Lua scripts present in `lua/` within the [configuration directory](../preferences-settings/config-directory.md). If e.g. a custom script is present as `lua/user/userscript.lua` the script manager will pick it up and it will be available through the scripts module in the lighttable. 
+
+If you are using the script-manager (which you likely are) you will then have to activate added scripts in the scripts utility module by selecting the appropriate folder and clicking the on/off button next to the corresponding script. 
+
+At startup, darktable will also automatically run the Lua scripts `$DARKTABLE/share/darktable/luarc` (where `$DARKTABLE` represents the darktable installation directory) and `luarc` in the darktable [configuration directory](../preferences-settings/config-directory.md). 
+
+If you want you could also write your scripts entirety into `luarc` (which is not very convenient). If you dont want to use or rely on the script manager you can also tell darktable to load a script by including it in one of the two `luarc` files (e.g. a script present in the config directory in `lua/user/user-script` could be loaded by adding `require "user/user-script"` to `luarc`. 
+

--- a/content/lua/basic-principles.md
+++ b/content/lua/basic-principles.md
@@ -6,7 +6,7 @@ weight: 20
 
 The central orchestrator for lua scripts is the __script manager__, which spawns the utility module __scripts__ in the lighttable. 
 
-In previous versions of darktable this had to be installed manually (see [darktables scripts](darktables-scripts.md)). If darktable detects `lua/tools/script-manager.lua` (e.g. from a previous version) within darktable's [configuration directory](../preferences-settings/config-directory.md) it will run the script manager in the config-directory instead of the bundled one. 
+In previous versions of darktable this had to be installed manually (see [darktables scripts](darktables-scripts.md)). If darktable detects `lua/tools/script_manager.lua` (e.g. from a previous version) within darktable's [configuration directory](../preferences-settings/config-directory.md) it will run the script manager in the config-directory instead of the bundled one. 
 
 Scripts can register callbacks to perform actions on various darktable events. This callback mechanism is the primary method of triggering lua actions. 
 

--- a/content/lua/basic-principles.md
+++ b/content/lua/basic-principles.md
@@ -15,11 +15,11 @@ Lua scripts can be disabled in [preferences/lua options](../preferences-settings
 darktable treats two kinds of location differently: Files that are _executed_ as Lua code, and directories that are _scanned_ for scripts:
 
 * Executed at startup:
-    * `$DARKTABLE/share/darktable/luarc`: run by darktable itself. This is the entry point that launches the script manager. It serves internal purposes only and should not be edited. $DARKTABLE is the programms installation directory.
-    * `\[configuration-directory]/luarc`: run by the script manager, if present. This is one way of running your own scripts (see below).
+    * `$DARKTABLE/share/darktable/luarc`: run by darktable itself. This is the entry point that launches the script manager. It serves internal purposes only and should not be edited. $DARKTABLE is the program's installation directory.
+    * `[configuration-directory]/luarc`: run by the script manager, if present. This is one way of running your own scripts (see below).
 * Scanned for `.lua` scripts (which then appear in the scripts-module):
     * `$DARKTABLE/share/darktable/lua-scripts/`: darktable's bundled scripts.
-    * `[configuration-directory]/lua/\[folder]/`: your own scripts (see below).
+    * `[configuration-directory]/lua/[folder]`: your own scripts (see below).
 
 The [configuration directory](../preferences-settings/config-directory.md) is specific to your OS. 
 
@@ -28,8 +28,8 @@ Thus you can __add your own scripts__ as follows:
     * Place your script e.g. in `[configuration-directory]/lua/user/myscript.lua`
     * Activate it in the scripts-module by selecting the appropriate folder (in this example "user") and clicking the on/off button next to the corresponding script. 
     * Note: For the scripts-module to pick up scripts they will need to be in a _subfolder_ of `configuration-directory/lua`.
-* using `luarc` (runs at startup automatically)
-    * Either write the code directly into `\[configuration-directory]/luarc`. This works, but is not tidy for anything beyond a few lines. The code runs at startup.
+* Use `luarc` (runs at startup automatically)
+    * Either write the code directly into `[configuration-directory]/luarc`. This works, but is not tidy for anything beyond a few lines. 
     * Or keep the code in its own file and `require` through `luarc`: E.g. a script present in `[configuration-directory]/lua/userscript.lua` could be loaded by adding `require "userscript"` (note that .lua is omitted here).
 
 

--- a/content/lua/darktables-scripts.md
+++ b/content/lua/darktables-scripts.md
@@ -1,26 +1,38 @@
 ---
-title: pre-existing scripts
-id: installation
+title: darktables scripts
+id: darktables-scripts
 weight: 15
 ---
 
-## Download and Install
+## from 5.6 onward
+
+A collection of scripts is included with darktable. They can be disabled in [preferences > lua](../preferences-settings/lua-options.md). 
+
+Starting with darktable 5.6, the lua-scripts are included with the release, so they no longer have to installed separately. 
+
+See [basic principles](basic-principles.md) for an explanation of how darktable loads Lua scripts. 
+
+Documentation for darktable's scripts is available in the [lua docs](https://docs.darktable.org/lua/stable/lua.scripts.manual/scripts/).
+
+## pre 5.6
+
+Pre 5.6 the scripts were not bundled and had to be installed using the following instructions. 
+
+### Download and Install
 
 A collection of scripts is available in the [lua-scripts repository](https://github.com/darktable-org/lua-scripts). This also includes the script manager, which makes it easier to enable or disable individual scripts from the GUI. Documentation for these lua scripts is included in the [lua docs](https://docs.darktable.org/lua/stable/lua.scripts.manual/scripts/).
-
-Starting with darktable 5.6, the lua-scripts are included with the release, so they no longer have to installed separately. If the lua-scripts are already installed, the installed version will be used instead of the bundled version.
 
 To use these existing scripts in versions before 5.6, they must be installed in darktable. This can in most cases be done within darktable's GUI, but depends on your OS and chosen method of installation. 
 
 In any case, darktable should be started at least once to set up its directories. The config directories for most installation types are listed on the [configuration directory](../preferences-settings/config-directory.md) page.
 
-If you don’t want any lua scripts running they can be disabled in [preferences/lua options](../preferences-settings/lua-options.md).
+Documentation for darktable's scripts is available in the [lua docs](https://docs.darktable.org/lua/stable/lua.scripts.manual/scripts/).
 
-### Linux Package, AppImage and Flatpak
+#### Linux Package, AppImage and Flatpak
 
 The Lua scripts can be installed using darktable's GUI. Ensure git is installed on your system. If it isn't, use the package manager to install it. In the lighttable view, expand the lua scripts installer module in the lower-left corner. Ensure that select action: install scripts is selected, then click execute. Restart darktable once for the scripts module to appear in the lower-left corner. 
 
-### Linux Snap Packages
+#### Linux Snap Packages
 
 Installation through darktable's GUI is currently [broken](https://github.com/darktable-org/darktable/issues/20074), so you will have to take the following approach:
 
@@ -32,7 +44,7 @@ Ensure git is installed on your system. If it isn't, use the package manager to 
 
 Restart darktable twice, and the scripts module should appear in the lower-left corner.
 
-### macOS
+#### macOS
 
 The Lua scripts can be installed by using darktable's GUI. In lighttable view, expand the lua scripts installer module in the lower-left corner. Ensure that select action: install scripts is selected, then click execute. Restart darktable once for the scripts module to appear in the lower-left corner.
 
@@ -41,32 +53,32 @@ Alternatively you could use the console. Ensure git is installed on your system.
     cd ~/.config/darktable/
     git clone https://github.com/darktable-org/lua-scripts.git lua
 
-### Windows
+#### Windows
 
 Ensure git is installed on your system. Git can be obtained from [git for windows](https://gitforwindows.org/), or using Windows package manager winget inside a command prompt with `winget install git.git`. If you use the gitforwindows.org distribution, install the Git Bash Shell also as it will aid in debugging the scripts if necessary. 
 
 The Lua scripts can now be installed by using darktable's GUI. In lighttable view, expand the lua scripts installer module in the lower-left corner. Ensure that select action: install scripts is selected, then click execute. Restart darktable once for the scripts module to appear in the lower-left corner.
 
-## Updating
+### Updating
 
 To update the script repository, either use the scripts module GUI or open a terminal or command prompt and run the following commands: 
 
-### Snap
+#### Snap
 
     cd ~/snap/darktable/current/lua
     git pull
 
-### Flatpak
+#### Flatpak
 
     cd ~/.var/app/org.darktable.Darktable/config/darktable/lua
     git pull
 
-### Linux and MacOS
+#### Linux and MacOS
 
     cd ~/.config/darktable/lua/
     git pull
 
-### Windows
+#### Windows
 
     cd %LOCALAPPDATA%\darktable\lua
     git pull

--- a/content/lua/darktables-scripts.md
+++ b/content/lua/darktables-scripts.md
@@ -1,5 +1,5 @@
 ---
-title: darktables scripts
+title: darktable's scripts
 id: darktables-scripts
 weight: 15
 ---

--- a/content/lua/darktables-scripts.md
+++ b/content/lua/darktables-scripts.md
@@ -28,11 +28,11 @@ In any case, darktable should be started at least once to set up its directories
 
 Documentation for darktable's scripts is available in the [lua docs](https://docs.darktable.org/lua/stable/lua.scripts.manual/scripts/).
 
-#### Linux Package, AppImage and Flatpak
+__Linux Package, AppImage and Flatpak__
 
 The Lua scripts can be installed using darktable's GUI. Ensure git is installed on your system. If it isn't, use the package manager to install it. In the lighttable view, expand the lua scripts installer module in the lower-left corner. Ensure that select action: install scripts is selected, then click execute. Restart darktable once for the scripts module to appear in the lower-left corner. 
 
-#### Linux Snap Packages
+__Linux Snap Packages__
 
 Installation through darktable's GUI is currently [broken](https://github.com/darktable-org/darktable/issues/20074), so you will have to take the following approach:
 
@@ -44,7 +44,7 @@ Ensure git is installed on your system. If it isn't, use the package manager to 
 
 Restart darktable twice, and the scripts module should appear in the lower-left corner.
 
-#### macOS
+__macOS__
 
 The Lua scripts can be installed by using darktable's GUI. In lighttable view, expand the lua scripts installer module in the lower-left corner. Ensure that select action: install scripts is selected, then click execute. Restart darktable once for the scripts module to appear in the lower-left corner.
 
@@ -53,32 +53,32 @@ Alternatively you could use the console. Ensure git is installed on your system.
     cd ~/.config/darktable/
     git clone https://github.com/darktable-org/lua-scripts.git lua
 
-#### Windows
+__Windows__
 
 Ensure git is installed on your system. Git can be obtained from [git for windows](https://gitforwindows.org/), or using Windows package manager winget inside a command prompt with `winget install git.git`. If you use the gitforwindows.org distribution, install the Git Bash Shell also as it will aid in debugging the scripts if necessary. 
 
 The Lua scripts can now be installed by using darktable's GUI. In lighttable view, expand the lua scripts installer module in the lower-left corner. Ensure that select action: install scripts is selected, then click execute. Restart darktable once for the scripts module to appear in the lower-left corner.
 
-### Updating
+__Updating__
 
 To update the script repository, either use the scripts module GUI or open a terminal or command prompt and run the following commands: 
 
-#### Snap
+__Snap__
 
     cd ~/snap/darktable/current/lua
     git pull
 
-#### Flatpak
+__Flatpak__
 
     cd ~/.var/app/org.darktable.Darktable/config/darktable/lua
     git pull
 
-#### Linux and MacOS
+__Linux and MacOS__
 
     cd ~/.config/darktable/lua/
     git pull
 
-#### Windows
+__Windows__
 
     cd %LOCALAPPDATA%\darktable\lua
     git pull

--- a/content/lua/overview.md
+++ b/content/lua/overview.md
@@ -6,7 +6,7 @@ weight: 10
 
 Lua scripts can be used to define actions for darktable to perform when an event is triggered. One example might be calling an external application during file export in order to apply additional processing steps outside of darktable.
 
-[Lua](http://www.lua.org/) is an independent project founded in 1993, providing a powerful, fast, lightweight, embeddable scripting language. Lua is widely used by many open source applications, in commercial programs, and for games programming. darktable uses Lua version 5.4. Describing the principles and syntax of Lua is beyond the scope of this usermanual. For a detailed introduction see the [Lua reference manual](http://www.lua.org/manual/5.4/manual.html).
+[Lua](http://www.lua.org/) is an independent project founded in 1993, providing a powerful, fast, lightweight, embeddable scripting language. Lua is widely used by many open source applications, in commercial programs, and for games programming. darktable uses Lua version 5.4. Describing the principles and syntax of Lua is beyond the scope of this manual. For a detailed introduction see the [Lua reference manual](http://www.lua.org/manual/5.4/manual.html).
 
 darktable comes with a number of [scripts included](darktables-scripts.md). The central orchestrator for scripts is the script manager (see [basic principles](basic-principles.md)).
 

--- a/content/lua/overview.md
+++ b/content/lua/overview.md
@@ -6,9 +6,9 @@ weight: 10
 
 Lua scripts can be used to define actions for darktable to perform when an event is triggered. One example might be calling an external application during file export in order to apply additional processing steps outside of darktable.
 
-[Lua](http://www.lua.org/) is an independent project founded in 1993, providing a powerful, fast, lightweight, embeddable scripting language. Lua is widely used by many open source applications, in commercial programs, and for games programming.
+[Lua](http://www.lua.org/) is an independent project founded in 1993, providing a powerful, fast, lightweight, embeddable scripting language. Lua is widely used by many open source applications, in commercial programs, and for games programming. darktable uses Lua version 5.4. Describing the principles and syntax of Lua is beyond the scope of this usermanual. For a detailed introduction see the [Lua reference manual](http://www.lua.org/manual/5.4/manual.html).
 
-darktable uses Lua version 5.4. Describing the principles and syntax of Lua is beyond the scope of this usermanual. For a detailed introduction see the [Lua reference manual](http://www.lua.org/manual/5.4/manual.html).
+darktable comes with a number of [scripts included](darktables-scripts.md). The central orchestrator for scripts is the script manager (see [basic principles](basic-principles.md)).
 
 The following sections will provide you with a brief introduction to how Lua scripts can be used within darktable. The comprehensive documentation on Lua Scripting in darktable can be found in the [darktable lua documentation](https://docs.darktable.org/lua/stable/).
 

--- a/content/preferences-settings/lua-options.md
+++ b/content/preferences-settings/lua-options.md
@@ -4,6 +4,18 @@ id: lua-options
 weight: 140
 ---
 
+### From 5.6 onward 
+
+These settings control how lua scripts are handled. 
+
+check for updated lua scripts on start up
+: automatically update (bundled) scripts to current version.
+
+disable lua scripts
+: do not run bundled lua scripts. 
+
+Note: _disable lua scripts_ is not displayed if darktable detects `lua/tools/script_manager.lua` in the [configuration directory](config-directory.md) (e.g. when installed using a previous version of darktable).
+
 ### Pre 5.6 
 
 These set up the behavior of the [Lua scripts installer](../module-reference/utility-modules/lighttable/lua-scripts-installer.md).
@@ -13,14 +25,3 @@ lua scripts installer log debug messages
 
 lua scripts installer don't show again
 : Check this box to hide the Lua scripts installer in the lighttable if no lua scripts are installed.
-
-
-### From 5.6 onward 
-
-These settings control how lua scripts are handled. 
-
-check for updated lua scripts on start up
-: automatically update (bundled) scripts to current version.
-
-disable lua scripts
-: do not run bundled lua scripts (this option is only available if no user defined lua scripts are detected in the [configuration directory](config-directory.md).

--- a/content/preferences-settings/lua-options.md
+++ b/content/preferences-settings/lua-options.md
@@ -16,6 +16,9 @@ disable lua scripts
 
 Note: _disable lua scripts_ is not displayed if darktable detects `lua/tools/script_manager.lua` in the [configuration directory](config-directory.md) (e.g. when installed using a previous version of darktable).
 
+per-script configuration options (dropdown)
+: allows selecting lua scripts to adjust settings they might contain. The available settings will then appear below. The lua scripts have to be  _activated_ in the scripts-module to become available here.
+
 ### Pre 5.6 
 
 These set up the behavior of the [Lua scripts installer](../module-reference/utility-modules/lighttable/lua-scripts-installer.md).

--- a/content/preferences-settings/lua-options.md
+++ b/content/preferences-settings/lua-options.md
@@ -12,7 +12,7 @@ check for updated lua scripts on start up
 : automatically update (bundled) scripts to current version.
 
 disable lua scripts
-: do not run bundled lua scripts. 
+: do not run lua scripts (bundled and user defined). 
 
 Note: _disable lua scripts_ is not displayed if darktable detects `lua/tools/script_manager.lua` in the [configuration directory](config-directory.md) (e.g. when installed using a previous version of darktable).
 

--- a/content/preferences-settings/lua-options.md
+++ b/content/preferences-settings/lua-options.md
@@ -14,7 +14,8 @@ check for updated lua scripts on start up
 disable lua scripts
 : do not run lua scripts (bundled and user defined). 
 
-Note: _disable lua scripts_ is not displayed if darktable detects `lua/tools/script_manager.lua` in the [configuration directory](config-directory.md) (e.g. when installed using a previous version of darktable).
+Note: If you have a previous lua scripts installation (e.g. Lua API 9.6.0 from darktable 5.4) in your [configuration directory](config-directory.md) the option _disable scripts_ will not be displayed. After (automatically) updating the scripts through the script manager the option will appear. 
+
 
 per-script configuration options (dropdown)
 : allows selecting lua scripts to adjust settings they might contain. The available settings will then appear below. The lua scripts have to be  _activated_ in the scripts-module to become available here.


### PR DESCRIPTION
Some more updates on the lua docs upon @wpferguson s comments and some things I found out myself.

@wpferguson [commented](https://github.com/darktable-org/dtdocs/pull/938#issuecomment-4952163864) in a previous PR:

>     * In the overview section after the link to the Lua reference manual how about adding a link to darktable's Lua documentation (https://darktable-org.github.io/luadocs/)?

done (but pointing to [darktable.org](https://docs.darktable.org/lua/stable/)
 
>     * Instead of pre-existing scripts maybe just call it darktable scripts and then wrap the discussion into a 5.6 and above and prior 5.6 which is most of the page.

done
 
>     * basic principles: luarc files: You might say that darktable starts script_manager and script_manager checks for a user luarc file and executes it if it's found.  My concern with `$DARKTABLE/share/luarc` is that user's may think they need to modify it, which they don't.

done

>     * In the keeping tidy section the luarc line should be `require "user/user-script"`.  Lua automatically appends `.lua` when it searches.

done

 
>     * Lua API - change the link to the online (and up to date) Lua API manual, https://darktable-org.github.io/luadocs/lua.api.manual/

not done - I hope we will get https://docs.darktable.org/lua/stable/ running again soon(tm) so I left the links. 


@wpferguson please review :-) 
