### PR TITLE
Add note to denoise about hidden exposure compensation

### DIFF
--- a/content/module-reference/processing-modules/denoise-profiled.md
+++ b/content/module-reference/processing-modules/denoise-profiled.md
@@ -66,11 +66,14 @@ Note that sliders are provided with minimum and maximum values by default. Howev
 profile
 : darktable automatically determines the camera model and ISO based on the Exif data of your raw file, and searches for a corresponding profile in its database. If your image has an intermediate ISO value, settings will be interpolated between the two closest datasets in the database, and this interpolated setting will show up as the first line in the combo box. You can also manually override this selection if necessary. Re-selecting the top-most entry in the combo box will return you to the default profile.
 
-mode
-: Choose which denoising algorithm to use (see above), and whether to present the simplified ("auto") or full manual interface for that algorithm.
+compensate highlight preservation
+: Some cameras underexpose the raw file in specific modes such as HDR, dynamic range expansion, HLG or AutoLightingOptimizer to protect the highlights. When enabled, reduces the ISO used for denoise by the factor of the camera's hidden exposure bias. This control appears only when such a mode is detected in the image's Exif data.
 
 whitebalance-adaptive transform
 : As the white balance amplifies each of the RGB channels differently, each channel exhibits different noise levels. This checkbox makes the selected algorithm adapt to the white balance adjustments. This option should be disabled on the second instance if you have applied a first instance with a color blend mode.
+
+mode
+: Choose which denoising algorithm to use (see above), and whether to present the simplified ("auto") or full manual interface for that algorithm.
 
 adjust autoset parameters (auto modes only)
 : Automatically adjust all the other parameters on the current denoising algorithm using a single slider. This is particularly useful when you have had to increase the exposure on an underexposed image, which normally introduces additional noise (as if you had taken the shot with a higher ISO). This control compensates for that by using settings similar to those used for a higher ISO image. The "effective ISO" used by the denoise algorithm is the actual ISO used, multiplied by the value of this slider. 


### PR DESCRIPTION
Relates to dtdocs issue: https://github.com/darktable-org/dtdocs/issues/947

Add to _denoise (profiled)_ about the highlight compensation checkbox (only visible if camera adjusted exposure in certain modes).

Also re-arranged order of some options to match what I saw during testing.
