### PR TITLE
Mention Canon HTP

### DIFF
--- a/content/module-reference/processing-modules/denoise-profiled.md
+++ b/content/module-reference/processing-modules/denoise-profiled.md
@@ -67,7 +67,7 @@ profile
 : darktable automatically determines the camera model and ISO based on the Exif data of your raw file, and searches for a corresponding profile in its database. If your image has an intermediate ISO value, settings will be interpolated between the two closest datasets in the database, and this interpolated setting will show up as the first line in the combo box. You can also manually override this selection if necessary. Re-selecting the top-most entry in the combo box will return you to the default profile.
 
 compensate highlight preservation
-: Some cameras underexpose the raw file in specific modes such as HDR, dynamic range expansion, HLG or AutoLightingOptimizer to protect the highlights. When enabled, reduces the ISO used for denoise by the factor of the camera's hidden exposure bias. This control appears only when such a mode is detected in the image's Exif data.
+: Some cameras underexpose the raw file in specific modes such as HDR, dynamic range expansion, highlight tone priority, HLG or AutoLightingOptimizer to protect the highlights. When enabled, reduces the ISO used for denoise by the factor of the camera's hidden exposure bias. This control appears only when such a mode is detected in the image's Exif data.
 
 whitebalance-adaptive transform
 : As the white balance amplifies each of the RGB channels differently, each channel exhibits different noise levels. This checkbox makes the selected algorithm adapt to the white balance adjustments. This option should be disabled on the second instance if you have applied a first instance with a color blend mode.

--- a/content/module-reference/processing-modules/exposure.md
+++ b/content/module-reference/processing-modules/exposure.md
@@ -42,7 +42,7 @@ compensate camera exposure (manual mode)
 : Automatically remove the camera exposure bias (taken from the image's Exif data).
 
 highlight preservation mode (manual mode)
-: Some cameras underexpose the raw file in specific modes such as HDR, dynamic range expansion, HLG or AutoLightingOptimizer to protect the highlights. When enabled, it restores the withheld exposure (the amount, in EV, is shown on the button). This control appears only when such a mode is detected in the image's Exif data.
+: Some cameras underexpose the raw file in specific modes such as HDR, dynamic range expansion, highlight tone priority, HLG or AutoLightingOptimizer to protect the highlights. When enabled, it restores the withheld exposure (the amount, in EV, is shown on the button). This control appears only when such a mode is detected in the image's Exif data.
 
 exposure (manual mode)
 : Increase (move to the right) or decrease (move to the left) the exposure value (EV). To adjust by more than the default limits shown on the slider, right click and enter the desired value up to +/-18 EV (see [module controls](../../darkroom/processing-modules/module-controls.md)).


### PR DESCRIPTION
Relates to darktable PR: https://github.com/darktable-org/darktable/pull/21408

Mention that the Canon Highlight Tone Priority setting in the Exif data is recognised. The docs don't give details of what darktable does with the other, similar, Exif settings - they all do stuff like this:

```c
 img->exif_highlight_preservation += 1.0f;
```

So I simply add it to the list of things which affect `exif_highlight_preservation`.
