### PR TITLE
Make translations sort on name

### DIFF
--- a/config-epub.yaml
+++ b/config-epub.yaml
@@ -5,51 +5,39 @@ languages:
   en:
     title: darktable user manual
     languageName: English
-    weight: 1
   fr:
     title: darktable user manual
     languageName: Français
-    weight: 2
   de:
     title: darktable user manual
     languageName: German
-    weight: 4
   eo:
     title: darktable user manual
     languageName: Esperanto
-    weight: 5
   es:
     title: darktable user manual
     languageName: Español
-    weight: 6
   gl:
     title: darktable user manual
     languageName: Galician
-    weight: 7
   it:
     title: darktable user manual
     languageName: Italian
-    weight: 8
   pl:
     title: darktable user manual
     languageName: Polish
-    weight: 9
   pt_br:
     title: manual do usuário darktable
     languageName: Português
-    weight: 10
   uk:
     title: darktable user manual
     languageName: Ukrainian
-    weight: 11
   nl:
     title: darktable user manual
     languageName: Dutch
-    weight: 12
   lo:
     title: darktable user manual
     languageName: Lao
-    weight: 13
 theme:
   - hugo-darktable-docs-epub-theme
 markup:

--- a/config-pdf.yaml
+++ b/config-pdf.yaml
@@ -5,51 +5,39 @@ languages:
   en:
     title: darktable user manual
     languageName: English
-    weight: 1
   fr:
     title: darktable user manual
     languageName: Français
-    weight: 2
   de:
     title: darktable user manual
     languageName: German
-    weight: 4
   eo:
     title: darktable user manual
     languageName: Esperanto
-    weight: 5
   es:
     title: darktable user manual
     languageName: Español
-    weight: 6
   gl:
     title: darktable user manual
     languageName: Galician
-    weight: 7
   it:
     title: darktable user manual
     languageName: Italian
-    weight: 8
   pl:
     title: darktable user manual
     languageName: Polish
-    weight: 9
   pt_br:
     title: manual do usuário darktable
     languageName: Português
-    weight: 10
   uk:
     title: darktable user manual
     languageName: Ukrainian
-    weight: 11
   nl:
     title: darktable user manual
     languageName: Dutch
-    weight: 12
   lo:
     title: darktable user manual
     languageName: Lao
-    weight: 13
 theme:
   - hugo-darktable-docs-pdf-theme
 markup:

--- a/config.yaml
+++ b/config.yaml
@@ -5,51 +5,39 @@ languages:
   en:
     title: darktable user manual
     languageName: English
-    weight: 1
   fr:
     title: darktable user manual
     languageName: Français
-    weight: 2
   de:
     title: darktable user manual
     languageName: German
-    weight: 4
   eo:
     title: darktable user manual
     languageName: Esperanto
-    weight: 5
   es:
     title: darktable user manual
     languageName: Español
-    weight: 6
   gl:
     title: darktable user manual
     languageName: Galician
-    weight: 7
   it:
     title: darktable user manual
     languageName: Italian
-    weight: 8
   pl:
     title: darktable user manual
     languageName: Polish
-    weight: 9
   pt_br:
     title: manual do usuário darktable
     languageName: Português
-    weight: 10
   uk:
     title: darktable user manual
     languageName: Ukrainian
-    weight: 11
   nl:
     title: darktable user manual
     languageName: Dutch
-    weight: 12
   lo:
     title: darktable user manual
     languageName: Lao
-    weight: 13
 theme:
   - hugo-darktable-docs-theme
 markup:

--- a/themes/hugo-darktable-docs-pdf-theme/layouts/_default/single.html
+++ b/themes/hugo-darktable-docs-pdf-theme/layouts/_default/single.html
@@ -11,9 +11,9 @@
     {{ .Content }}
 
     {{ if .IsTranslated }}
-    <h4>{{ i18n "translations" }}</h4>
+    <h4>{{ i18n "translations" | default "translations" }}</h4>
     <ul>
-        {{ range .Translations }}
+        {{ range (sort .Translations ".Language.LanguageName")  }}
         <li><a href="{{ .Permalink }}">
             {{ .Lang }}: {{ .Title }}{{ if .IsPage }}{{ end }}
         </a></li>

--- a/themes/hugo-darktable-docs-theme/layouts/_default/single.html
+++ b/themes/hugo-darktable-docs-theme/layouts/_default/single.html
@@ -24,7 +24,7 @@
     {{ if .IsTranslated }}
     <h3 class="translations_head">{{ i18n "translations" | default "translations" }}</h3>
     <ul class="translations">
-        {{ range .Translations }}
+        {{ range (sort .Translations ".Language.LanguageName")  }}
         <li><a href="{{ .RelPermalink }}">
             {{ .Language.LanguageName }}: {{ .Title }}{{ if .IsPage }}{{ end }}
         </a></li>

--- a/themes/hugo-darktable-docs-theme/layouts/index.html
+++ b/themes/hugo-darktable-docs-theme/layouts/index.html
@@ -10,7 +10,7 @@
     {{ if .IsTranslated }}
     <h3 class="translations_head">{{ i18n "translations" | default "translations" }}</h3>
     <ul class="translations">
-        {{ range .Translations }}
+        {{ range (sort .Translations ".Language.LanguageName")  }}
         <li><a href="{{ .RelPermalink }}">
             {{ .Language.LanguageName }}: {{ .Title }}{{ if .IsPage }}{{ end }}
         </a></li>

--- a/themes/hugo-darktable-docs-theme/layouts/partials/page-header-navbar-large.html
+++ b/themes/hugo-darktable-docs-theme/layouts/partials/page-header-navbar-large.html
@@ -65,7 +65,7 @@
               href="{{ .Permalink }}"
               >{{ .Site.Language.LanguageName }}</a
             >
-            {{ range .Translations }}
+            {{ range (sort .Translations ".Language.LanguageName")  }}
               <a
                 class="dropdown-item"
                 hreflang="{{ .Language.Lang }}"


### PR DESCRIPTION
When I added Lao to the languages I simply added it to the end of the list, and incremented the weight given to Dutch. I see now that Dutch and Lao appear at the end of the list which seems odd. Instead of having to always change a lot of weights when any new language is added, this PR attempts to sort the languages by name, which seems sensible to me.