### PR TITLE
Describe image choice for darkroom

### DIFF
--- a/content/darkroom/overview.md
+++ b/content/darkroom/overview.md
@@ -4,7 +4,17 @@ id: overview
 weight: 10
 ---
 
-The darkroom view is where you develop your images. The center panel contains the image currently being edited.
+The darkroom view is where you develop your images. There are multiple ways to start developing an image in the darkroom:
+
+1. double-click an image in the [lighttable view](../lighttable).
+2. use the [keyboard shortcut](../preferences-settings/) (which by default is a D) from any view.
+3. click _darkroom_ in the top banner from any view.
+
+In the latter two methods, the image used will use the first selected image in the current lighttable view, or the first image in the current [collection](../module-reference/utility-modules/shared/collections.md) if no image is selected.
+
+If the [_prioritize the hovered image over the selected images_ preference](../preferences-settings/lighttable#general) is selected then an image under the cursor in the lighttable, filmstrip, or map will be the one opened in the darkroom, regardless of other selections.
+
+The center panel contains the image currently being edited.
 
 # zoom
 


### PR DESCRIPTION
Relates to darktable issue: https://github.com/darktable-org/darktable/pull/21613

I didn't find any existing description of which image gets used, so I tried to add something about this. Open to suggestions of a better place or description.
