### PR TITLE
Remove mention of preferences for slider-color

### DIFF
--- a/content/module-reference/processing-modules/white-balance.md
+++ b/content/module-reference/processing-modules/white-balance.md
@@ -78,7 +78,7 @@ red/green/blue
 
 ## colored sliders
 
-By default the module's sliders are monochrome. However, two flavors of colored sliders can be enabled in [preferences > darkroom > white balance slider colors](../../preferences-settings/darkroom.md) or by clicking on the 'scene illuminant temp' section label in the module.
+By default the module's sliders are monochrome. However, two flavors of colored sliders can be enabled by clicking on the 'scene illuminant temp' section label in the module.
 
 no color (default)
 : The background of the sliders is not colored.


### PR DESCRIPTION
The option has apparently been removed in the preferences - at least I can't find it. 