### PR TITLE
feat: clarify using test environment

### DIFF
--- a/content/preferences-settings/storage.md
+++ b/content/preferences-settings/storage.md
@@ -22,7 +22,7 @@ how many snapshots to keep
 create XMP files
 : XMP sidecar files provide a redundant method of saving the changes that you have made to an image, in addition to the changes saved to darktable's database. This option allows you to choose when files will _first be written_. Once written, they will subsequently be updated each time you edit or add a tag to the image. Choose from:
 
-: - _never_: Don't write sidecar files. This can be useful if you are running multiple version of darktable for development/testing purposes but is not normally recommended,
+: - _never_: Don't write sidecar files. This can be useful if you are running multiple version of darktable for [development/testing purposes](../special-topics/test-environment.md#3-protect-your-existing-edits) but is not normally recommended,
 : - _on import_: A sidecar file will be written as soon as you add an image to darktable's library,
 : - _after edit_: A sidecar will not be written until the first time you edit or add a tag to an image.
 

--- a/content/special-topics/program-invocation/invocation-per-OS.md
+++ b/content/special-topics/program-invocation/invocation-per-OS.md
@@ -6,21 +6,24 @@ weight: 5
 
 `darktable` and the other binaries (e.g. `darktable-cltest`) can be executed from the console as follows:
 
-Linux
+## Linux
+
 * Installed as package or snap: `darktable`
 * Flatpak: `flatpak run org.darktable.Darktable`
      + To run e.g. `darktable-cltest`: `flatpak run --command=darktable-cltest org.darktable.Darktable --arguments-go-here`.
 * AppImage: Navigate to containing folder, then `./darktable.Appimage` (or however you named the file)
      + To run e.g. `darktable-cltest`: `./darktable.Appimage darktable-cltest`
-     + An additional option to run the various binaries included in darktable (e.g. `darktable-cltest` or `darktable-cli`) is through a symbolic link: 
+     + An additional option to run the various binaries included in darktable (e.g. `darktable-cltest` or `darktable-cli`) is through a symbolic link:
           * Create a symbolic link to your AppImage and call it e.g. `darktable-cli`.
           * Then, when calling the AppImage through the symbolic link with `./darktable-cli`, the code inside the package checks if there is a binary file inside the AppImage with a name that matches the symlink name. If so, it will be run instead of the default one.
-     
-Windows
-* Navigate to darktable's program folder: `cd "\Program Files\darktable\bin"` then execute `.\darktable.exe`. 
+
+## Windows
+
+* Navigate to darktable's program folder: `cd "\Program Files\darktable\bin"` then execute `.\darktable.exe`.
 * The other binaries e.g. `darktable-cltest.exe` are also located in this folder and can be called accordingly.
 
-macOS
+## macOS
+
 * Execute `/Applications/darktable.app/Contents/MacOS/darktable`.
 * The other binaries e.g. `darktable-cltest` are also located in this folder and can be called accordingly.
 

--- a/content/special-topics/test-environment.md
+++ b/content/special-topics/test-environment.md
@@ -77,15 +77,35 @@ b) Turn off XMP creation in the other installation's preferences
 
 For an independent installation that should not write XMP sidecar files:
 
-```
-darktable --configdir /path-to-test-config-dir --conf write_sidecar_files=never
-```
+Linux/macOS
+: Options:
+
+  ```
+  --configdir /path-to-test-config-dir --conf write_sidecar_files=never
+  ```
+
+Windows
+: Options:
+
+  ```
+  --configdir "C:\path-to-test-config" --conf "write_sidecar_files=never"
+  ```
 
 To additionally keep all changes to its library database in memory only:
 
-```
-darktable --configdir /path-to-test-config-dir --conf write_sidecar_files=never --library :memory:
-```
+Linux/macOS
+: Options:
+
+  ```
+  --configdir /path-to-test-config-dir --conf write_sidecar_files=never --library :memory:
+  ```
+
+Windows
+: Options:
+
+  ```
+  --configdir "C:\path-to-test-config" --conf "write_sidecar_files=never" --library ":memory:"
+  ```
 
 For the safest setup, use copies of the RAW files rather than relying on XMP creation being disabled.
 

--- a/content/special-topics/test-environment.md
+++ b/content/special-topics/test-environment.md
@@ -29,7 +29,7 @@ darktable stores its settings, presets, styles, and library database in its [con
 
 To prevent an installation from writing to the same configuration directory as another installation, launch it with the option `--configdir`, followed by the path to a new folder. If the folder does not exist yet, darktable creates and populates it automatically.
 
-You can run an experiment without persistent library changes by additionally setting `--library :memory:`, which keeps the library database in RAM. All changes to the database are discarded on exit: `darktable --configdir /path/to/test-config --library :memory:`
+You can run an experiment without making persistent changes to the library by specifying `--library :memory:`, which keeps the library database in RAM. All changes to the database are discarded on exit: `darktable --configdir /path/to/test-config --library :memory:`
 
 **Tip:** You can also copy an existing configuration directory into the new folder instead of starting from scratch. This allows the other installation to inherit your presets, styles, and keyboard shortcuts as a starting point, while both installations still run fully independently from then on. If you do this, take special care in step 3 to avoid affecting your existing edits.
 

--- a/content/special-topics/test-environment.md
+++ b/content/special-topics/test-environment.md
@@ -109,4 +109,4 @@ Windows
 
 For the safest setup, use copies of the RAW files rather than relying on XMP creation being disabled.
 
-**Caution:** If you cloned an existing installation's configuration directory for another installation, disable XMP file creation as described above under b). Alternatively, remove (not delete) all photos from the library in the new installation. This removes them only from the library database; it does not delete the files from disk. Otherwise, you could interfere with edits made by the original installation.
+**Caution:** If you cloned an existing installation's configuration directory for another installation, disable XMP file creation as described above in Step 3b. Alternatively, remove (not delete) all photos from the library in the new installation. This removes them only from the library database; it does not delete the files from disk. Otherwise, you could interfere with edits made by the original installation.

--- a/content/special-topics/test-environment.md
+++ b/content/special-topics/test-environment.md
@@ -4,41 +4,46 @@ id: test-environment
 weight: 100
 ---
 
-To run a second version of darktable on your computer, for example to try out a [nightly build](https://github.com/darktable-org/darktable/releases/nightly), you can set up a second configuration without affecting your main installation. 
+To run multiple installations of darktable on your computer, for example to try out a [nightly build](https://github.com/darktable-org/darktable/releases/nightly), you can give each installation its own configuration without affecting the others.
 
 Three steps are needed:
 
-1. Install the second darktable version without overwriting the existing one.
+1. Install the additional version of darktable without overwriting the existing installation.
 2. Give it its own configuration directory.
-3. Make sure it doesn't touch your existing edits.
+3. Make sure it doesn't touch edits created by other installations.
 
 ## 1. Install the version you want to test
 
 Linux
-: Easiest with an AppImage. Just download it and make it executable.
+: If an [AppImage](./program-invocation/invocation-per-OS.md#linux) is available, this is the easiest option. Just download it and make it executable. Alternatively, you can build darktable from source and install it with a custom `--prefix` (e.g. `--prefix /opt/darktable-nightly`).
 
 Windows
-: Install it into its own separate directory. 
+: Install it into its own separate directory.
 
 macOS
 : Rename the `.app` file before moving it to `/Applications` (e.g. `darktable-nightly.app`), instead of overwriting the existing one.
 
 ## 2. Set up a separate configuration directory
 
-darktable stores its settings, presets, styles, and database in its configuration directory. The default folder depends on your OS and chosen method of installation and is [documented here](../preferences-settings/config-directory.md).
+darktable stores its settings, presets, styles, and library database in its [configuration directory](../preferences-settings/config-directory.md). The default location depends on your operating system and installation method.
 
-To stop the second installation from writing into that same directory, launch it with the option `--configdir`, followed by the path to a new folder. If it doesn't exist yet, darktable creates and populates it automatically.
+To prevent an installation from writing to the same configuration directory as another installation, launch it with the option `--configdir`, followed by the path to a new folder. If the folder does not exist yet, darktable creates and populates it automatically.
 
-Tip: You can also copy your existing configuration directory into the new folder instead of starting from scratch. That way the test version inherits your presets, styles, and keyboard shortcuts as a starting point, while both installations still run fully independently from there on. This requires special care in step 3 to avoid affecting your existing edits.
+You can run an experiment without persistent library changes by additionally setting `--library :memory:`, which keeps the library database in RAM. All changes to the database are discarded on exit: `darktable --configdir /path/to/test-config --library :memory:`
+
+**Tip:** You can also copy an existing configuration directory into the new folder instead of starting from scratch. This allows the other installation to inherit your presets, styles, and keyboard shortcuts as a starting point, while both installations still run fully independently from then on. If you do this, take special care in step 3 to avoid affecting your existing edits.
 
 Linux
-: Execute from a terminal: `/path-to-appimage/darktable.AppImage --configdir /path-to-test-config`
-: For convenience, you can wrap this in a shell script or a `.desktop` file.
+: Run the following commands in a terminal:
+    * AppImage: `/path-to-appimage/darktable.AppImage --configdir /path-to-test-config-dir`
+    * Built binary: `/prefix-path-to-binary/darktable --configdir /path-to-test-config-dir`
+
+: For convenience, you can put the whole command in a shell script or a [`.desktop` file](https://specifications.freedesktop.org/desktop-entry/latest/) (see [darktable's `.desktop` file](https://github.com/darktable-org/darktable/blob/master/data/org.darktable.darktable.desktop.in) for an example).
 
 Windows
 : Either create a new shortcut for `darktable.exe`:
   1. Navigate to `C:\path-to-your-install\bin\`, right-click `darktable.exe` and choose _Show more options_ and then _Create shortcut_.
-  2. Under "Properties", add to the "Target" field: `"C:\path-to-your-install\bin\darktable.exe" --configdir "C:\path-to-test-config"`
+  2. Under the shortcut's "Properties", append the `--configdir` option to the "Target" field: `"C:\path-to-your-install\bin\darktable.exe" --configdir "C:\path-to-test-config"`
   3. Set "Start in" to the matching `bin` folder.
 
 : Or launch darktable from the terminal:
@@ -48,7 +53,7 @@ Windows
     ```
 
 macOS
-: An `.app` file can't be launched with extra parameters by double-clicking, so call the executable inside the app bundle directly from a terminal:
+: An `.app` file can't be launched with extra parameters by double-clicking, so launch the executable inside the app bundle directly from a terminal:
 
   ```
   /Applications/darktable-nightly.app/Contents/MacOS/darktable --configdir /path/to/new/config/dir
@@ -58,17 +63,30 @@ macOS
 
 ## 3. Protect your existing edits
 
-Edits are stored in two places: in the database inside the configuration directory, and, if enabled, in [XMP sidecar files](../overview/sidecar-files/sidecar.md) next to your RAW files. The database is already protected by step 2. For the XMP files, you have three options:
+Edits are stored in two places: in the library database inside the configuration directory, and, if enabled, in [XMP sidecar files](../overview/sidecar-files/sidecar.md) next to your RAW files. Step 2 gives the other installation its own library database, but XMP sidecar files are stored alongside the RAW files and are therefore shared between installations.
+
+To prevent the other installation from modifying existing XMP files, you have two options:
 
 a) Work with separate copies of your RAW files
-: Safest option. Use copies of your RAW files with the test version in a separate folder. Your originals and their XMP files stay untouched.
+: Safest option. Use copies of your RAW files with the other version in a separate folder. Your original RAW files and their XMP sidecars remain untouched.
 
-b) Turn off XMP creation in the test installation's preferences
-: Set _preferences / storage / create XMP files_ to "never". This lets you open folders with existing edits without changing their XMP files. Only affects the test version, since it has its own configuration.
+b) Turn off XMP creation in the other installation's preferences
+: Launch darktable with the additional `--conf write_sidecar_files=never` option. Alternatively, you can set _preferences / storage / create XMP files_ to "never" in the UI. This lets you open folders with existing edits without writing changes back to their XMP files. The setting only affects this installation because it has its own configuration.
 
-c) Pure in-memory mode
-: Launching darktable with the option `--library :memory:` keeps the database in RAM only, and all changes are discarded on exit: `darktable --configdir /path/to/test-config --library :memory:`
+## Summary
 
-For a lasting test setup, options a) or b) are practical. Option c) is handy for a quick, no-trace experiment.
+For an independent installation that should not write XMP sidecar files:
 
-**Caution:** If you cloned your main installation's configuration directory for the testing environment, make sure to either disable XMP creation as described above under b) or remove (not delete) all photos from the library in your testing environment. Otherwise you could interfere with your main installation's edits.
+```
+darktable --configdir /path-to-test-config-dir --conf write_sidecar_files=never
+```
+
+To additionally keep all changes to its library database in memory only:
+
+```
+darktable --configdir /path-to-test-config-dir --conf write_sidecar_files=never --library :memory:
+```
+
+For the safest setup, use copies of the RAW files rather than relying on XMP creation being disabled.
+
+**Caution:** If you cloned an existing installation's configuration directory for another installation, disable XMP file creation as described above under b). Alternatively, remove (not delete) all photos from the library in the new installation. This removes them only from the library database; it does not delete the files from disk. Otherwise, you could interfere with edits made by the original installation.


### PR DESCRIPTION
This is an attempt to improve clarity and ease of usage of the *using a test environment* section.

* Made usage of in-memory database clear
* Provided launch option protecting XMP files
* Provided TL;DR command line options
* Added links, etc.
