### PR TITLE
refined documentation for contrast & texture: edge protection

### DIFF
--- a/content/module-reference/processing-modules/contrast-texture.md
+++ b/content/module-reference/processing-modules/contrast-texture.md
@@ -48,7 +48,7 @@ detail level
 : Controls the scale of local contrast being affected. Higher values target finer detail; lower values shift the effect towards coarser, larger-scale contrasts.
 
 adjust edge protection
-: Controls how strictly the underlying guided filter reacts to edges. Higher values increase edge preservation, keeping strong transitions crisp. Lower values allow smoother transitions between regions, at the risk of introducing halos around high-contrast edges.
+: Controls how sensitively the underlying filter reacts to high-contrast edges. Lower values make for stronger local contrast around high-contrast edges at the risk of developing halos. Higher values allow for smoother transitions. 
 
 filter iterations
 : The number of passes of the guided filter to run. Increasing this further diffuses the filter's edges, which can help avoid artifacts, at the cost of processing speed.


### PR DESCRIPTION
Based on [this answer](https://discuss.pixls.us/t/merged-new-module-contrast-and-texture/59768/63?u=mino) by @jandren I tried to refine the documentation for edge protection.

Side-note @jandren : I think this setting should be called "edge detection" because "protection" feels off in the contrast of managing local contrast. 