### PR TITLE
Note about print flags cli options

### DIFF
--- a/content/preferences-settings/config-directory.md
+++ b/content/preferences-settings/config-directory.md
@@ -4,7 +4,11 @@ id: config-directory
 weight: 150
 ---
 
-darktable stores its settings, presets, styles, library database, etc. in a default directory. This directory's location depends on your operating system and installation method. It can be changed by using the `--config-dir` option (see [darktable invocation](../special-topics/program-invocation/darktable.md)).
+darktable stores its settings, presets, styles, library database, etc. in a default directory. This directory's location depends on your operating system and installation method. It can be changed by using the `--configdir` option (see [darktable invocation](../special-topics/program-invocation/darktable.md)).
+
+The location of the configuration directory (and of other darktable directories and files) can be found by running [darktable](../special-topics/program-invocation/darktable.md) (or [darktable-cli](../special-topics/program-invocation/darktable-cli.md)) with the `--print-paths` (or `--print-paths-as-flags`) option.
+
+## Default locations
 
 * Linux 
     + Installed via package manager or AppImage: `$HOME/.config/darktable`

--- a/content/special-topics/program-invocation/darktable-cli.md
+++ b/content/special-topics/program-invocation/darktable-cli.md
@@ -27,6 +27,8 @@ darktable-cli [<input file or folder>]
               [--icc-type <type>]
               [--icc-file <file>]
               [--icc-intent <intent>]
+              [--print-paths]
+              [--print-paths-as-flags]
               [--verbose]
               [--help [option]]
               [--core <darktable options>]
@@ -81,6 +83,12 @@ The user must supply an input filename and an output filename. All other paramet
 
 `--icc-intent <intent>` 
 : Specify the rendering intent. Defaults to "image specified". Use `--help icc-intent` to obtain a list of the supported intents. See [rendering intent](../../special-topics/color-management/rendering-intent) for a more detailed description of the available options.
+
+`--print-paths`
+: Print the resolved configdir, cachedir, tmpdir, datadir, moduledir, localedir and library paths for this install, honoring any of the overrides, then exit.
+
+`--print-paths-as-flags`
+: Like `--print-paths`, but printed as a single line of --flag value pairs ready to insert into another invocation's command line (for `darktable-cli` they need to be _after_ the `--core` flag).
 
 `--verbose`
 : Enables verbose output.

--- a/content/special-topics/program-invocation/darktable.md
+++ b/content/special-topics/program-invocation/darktable.md
@@ -26,6 +26,8 @@ darktable [-d {all,act_on,ai,cache,camctl,camsupport,common,control,
           [--tmpdir <tmp directory>]
           [--cachedir <user cache directory>]
           [--localedir <locale directory>]
+          [--print-paths]
+          [--print-paths-as-flags]
           [--luacmd <lua command>]
           [--noiseprofiles <noiseprofiles json file>]
           [--conf <key>=<value>]
@@ -77,6 +79,12 @@ All parameters are optional. In most cases darktable should be started without a
 
 `--localedir <locale directory>`
 : Define where darktable can find its language-specific text strings. The default location depends on your installation. Typical locations are `/opt/darktable/share/locale/` and `/usr/share/locale/`.
+
+`--print-paths`
+: Print the resolved configdir, cachedir, tmpdir, datadir, moduledir, localedir and library paths for this install, honoring any of the overrides, then exit.
+
+`--print-paths-as-flags`
+: Like `--print-paths`, but printed as a single line of --flag value pairs ready to insert into another invocation's command line.
 
 `--luacmd <lua command>`
 : A string containing lua commands to execute after lua initialization. These commands will be run after your “luarc” file.


### PR DESCRIPTION
Relates to darktable PR: https://github.com/darktable-org/darktable/pull/21898

Add new _--print-paths_ and _--print-paths-as-flags_ options to the listed command line options.
