### PR TITLE
Fix lua title typos

### DIFF
--- a/content/preferences-settings/config-directory.md
+++ b/content/preferences-settings/config-directory.md
@@ -16,7 +16,7 @@ darktable stores its settings, presets, styles, library database, etc. in a defa
 
 ## Notable files/folders:
 
-* `lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lu: basic principles](../lua/basic-principles.md).
+* `lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lua: basic principles](../lua/basic-principles.md).
 * `styles` (folder): User created styles
 * `darktablerc`: Main configuration file
 * `data.db` and `library.db`: Central libraries: Image File Locations, metadata, edits etc.

--- a/po/content.bg.po
+++ b/po/content.bg.po
@@ -16156,7 +16156,7 @@ msgstr ""
 #. type: Bullet: '* '
 #: content/preferences-settings/config-directory.md
 #, no-wrap
-msgid "`lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lu: basic principles](../lua/basic-principles.md).\n"
+msgid "`lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lua: basic principles](../lua/basic-principles.md).\n"
 msgstr ""
 
 #. type: Bullet: '* '

--- a/po/content.ca.po
+++ b/po/content.ca.po
@@ -16156,7 +16156,7 @@ msgstr ""
 #. type: Bullet: '* '
 #: content/preferences-settings/config-directory.md
 #, no-wrap
-msgid "`lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lu: basic principles](../lua/basic-principles.md).\n"
+msgid "`lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lua: basic principles](../lua/basic-principles.md).\n"
 msgstr ""
 
 #. type: Bullet: '* '

--- a/po/content.de.po
+++ b/po/content.de.po
@@ -18411,7 +18411,7 @@ msgstr "Erwähnenswerte Dateien/Ordner:"
 #. type: Bullet: '* '
 #: content/preferences-settings/config-directory.md
 #, no-wrap
-msgid "`lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lu: basic principles](../lua/basic-principles.md).\n"
+msgid "`lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lua: basic principles](../lua/basic-principles.md).\n"
 msgstr ""
 
 #. type: Bullet: '* '

--- a/po/content.eo.po
+++ b/po/content.eo.po
@@ -16406,7 +16406,7 @@ msgstr ""
 #. type: Bullet: '* '
 #: content/preferences-settings/config-directory.md
 #, no-wrap
-msgid "`lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lu: basic principles](../lua/basic-principles.md).\n"
+msgid "`lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lua: basic principles](../lua/basic-principles.md).\n"
 msgstr ""
 
 #. type: Bullet: '* '

--- a/po/content.es.po
+++ b/po/content.es.po
@@ -18201,7 +18201,7 @@ msgstr ""
 #. type: Bullet: '* '
 #: content/preferences-settings/config-directory.md
 #, no-wrap
-msgid "`lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lu: basic principles](../lua/basic-principles.md).\n"
+msgid "`lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lua: basic principles](../lua/basic-principles.md).\n"
 msgstr ""
 
 #. type: Bullet: '* '

--- a/po/content.fi.po
+++ b/po/content.fi.po
@@ -16437,7 +16437,7 @@ msgstr ""
 #. type: Bullet: '* '
 #: content/preferences-settings/config-directory.md
 #, no-wrap
-msgid "`lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lu: basic principles](../lua/basic-principles.md).\n"
+msgid "`lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lua: basic principles](../lua/basic-principles.md).\n"
 msgstr ""
 
 #. type: Bullet: '* '

--- a/po/content.fr.po
+++ b/po/content.fr.po
@@ -18561,7 +18561,7 @@ msgstr "Fichiers/dossiers notables :"
 #. type: Bullet: '* '
 #: content/preferences-settings/config-directory.md
 #, no-wrap
-msgid "`lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lu: basic principles](../lua/basic-principles.md).\n"
+msgid "`lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lua: basic principles](../lua/basic-principles.md).\n"
 msgstr "`lua` (dossier) : scripts Lua. Remarque : à partir de la version 5.6, les scripts Lua sont également fournis et ce dossier n'est pas obligatoire. Mais il sera pris en compte s'il est présent. Des scripts personnalisés peuvent être ajoutés dans un sous-dossier. Voir [Lua : principes de base](../lua/basic-principles.md).\n"
 
 #. type: Bullet: '* '

--- a/po/content.gl.po
+++ b/po/content.gl.po
@@ -16309,7 +16309,7 @@ msgstr ""
 #. type: Bullet: '* '
 #: content/preferences-settings/config-directory.md
 #, no-wrap
-msgid "`lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lu: basic principles](../lua/basic-principles.md).\n"
+msgid "`lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lua: basic principles](../lua/basic-principles.md).\n"
 msgstr ""
 
 #. type: Bullet: '* '

--- a/po/content.it.po
+++ b/po/content.it.po
@@ -17140,7 +17140,7 @@ msgstr ""
 #. type: Bullet: '* '
 #: content/preferences-settings/config-directory.md
 #, no-wrap
-msgid "`lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lu: basic principles](../lua/basic-principles.md).\n"
+msgid "`lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lua: basic principles](../lua/basic-principles.md).\n"
 msgstr ""
 
 #. type: Bullet: '* '

--- a/po/content.ja.po
+++ b/po/content.ja.po
@@ -16547,7 +16547,7 @@ msgstr ""
 #. type: Bullet: '* '
 #: content/preferences-settings/config-directory.md
 #, no-wrap
-msgid "`lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lu: basic principles](../lua/basic-principles.md).\n"
+msgid "`lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lua: basic principles](../lua/basic-principles.md).\n"
 msgstr ""
 
 #. type: Bullet: '* '

--- a/po/content.lo.po
+++ b/po/content.lo.po
@@ -17851,8 +17851,8 @@ msgstr "ໄຟລ໌/ໂຟນເດີທີ່ສຳຄັນ:"
 #. type: Bullet: '* '
 #: content/preferences-settings/config-directory.md
 #, no-wrap
-msgid "`lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lu: basic principles](../lua/basic-principles.md).\n"
-msgstr "`lua` (ໂຟນເດີ): ສະຄຣິບ Lua. ໝາຍເຫດ: ຕັ້ງແຕ່ເວີຊັນ 5.6 ເປັນຕົ້ນໄປ ສະຄຣິບ Lua ແມ່ນໄດ້ລວມມາພ້ອມແລ້ວ ແລະ ບໍ່ຈຳເປັນຕ້ອງມີໂຟນເດີນີ້ກໍໄດ້. ແຕ່ຖ້າມັນມີຢູ່ ລະບົບກໍຈະຍັງນຳໃຊ້ມັນ. ສາມາດເພີ່ມສະຄຣິບທີ່ກຳນົດເອງລົງໃນໂຟນເດີຍ່ອຍໄດ້. ເບິ່ງ [Lu: ຫຼັກການພື້ນຖານ](../lua/basic-principles.md).\n"
+msgid "`lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lua: basic principles](../lua/basic-principles.md).\n"
+msgstr "`lua` (ໂຟນເດີ): ສະຄຣິບ Lua. ໝາຍເຫດ: ຕັ້ງແຕ່ເວີຊັນ 5.6 ເປັນຕົ້ນໄປ ສະຄຣິບ Lua ແມ່ນໄດ້ລວມມາພ້ອມແລ້ວ ແລະ ບໍ່ຈຳເປັນຕ້ອງມີໂຟນເດີນີ້ກໍໄດ້. ແຕ່ຖ້າມັນມີຢູ່ ລະບົບກໍຈະຍັງນຳໃຊ້ມັນ. ສາມາດເພີ່ມສະຄຣິບທີ່ກຳນົດເອງລົງໃນໂຟນເດີຍ່ອຍໄດ້. ເບິ່ງ [Lua: ຫຼັກການພື້ນຖານ](../lua/basic-principles.md).\n"
 
 #. type: Bullet: '* '
 #: content/preferences-settings/config-directory.md

--- a/po/content.lv.po
+++ b/po/content.lv.po
@@ -16157,7 +16157,7 @@ msgstr ""
 #. type: Bullet: '* '
 #: content/preferences-settings/config-directory.md
 #, no-wrap
-msgid "`lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lu: basic principles](../lua/basic-principles.md).\n"
+msgid "`lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lua: basic principles](../lua/basic-principles.md).\n"
 msgstr ""
 
 #. type: Bullet: '* '

--- a/po/content.nl.po
+++ b/po/content.nl.po
@@ -18276,7 +18276,7 @@ msgstr ""
 #. type: Bullet: '* '
 #: content/preferences-settings/config-directory.md
 #, no-wrap
-msgid "`lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lu: basic principles](../lua/basic-principles.md).\n"
+msgid "`lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lua: basic principles](../lua/basic-principles.md).\n"
 msgstr ""
 
 #. type: Bullet: '* '

--- a/po/content.pl.po
+++ b/po/content.pl.po
@@ -18274,7 +18274,7 @@ msgstr ""
 #. type: Bullet: '* '
 #: content/preferences-settings/config-directory.md
 #, no-wrap
-msgid "`lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lu: basic principles](../lua/basic-principles.md).\n"
+msgid "`lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lua: basic principles](../lua/basic-principles.md).\n"
 msgstr ""
 
 #. type: Bullet: '* '

--- a/po/content.pot
+++ b/po/content.pot
@@ -16154,7 +16154,7 @@ msgstr ""
 #. type: Bullet: '* '
 #: content/preferences-settings/config-directory.md
 #, markdown-text, no-wrap
-msgid "`lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lu: basic principles](../lua/basic-principles.md).\n"
+msgid "`lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lua: basic principles](../lua/basic-principles.md).\n"
 msgstr ""
 
 #. type: Bullet: '* '

--- a/po/content.pt_br.po
+++ b/po/content.pt_br.po
@@ -18273,7 +18273,7 @@ msgstr ""
 #. type: Bullet: '* '
 #: content/preferences-settings/config-directory.md
 #, no-wrap
-msgid "`lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lu: basic principles](../lua/basic-principles.md).\n"
+msgid "`lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lua: basic principles](../lua/basic-principles.md).\n"
 msgstr ""
 
 #. type: Bullet: '* '

--- a/po/content.ta.po
+++ b/po/content.ta.po
@@ -17857,7 +17857,7 @@ msgstr "குறிப்பிடத்தக்க கோப்புகள�
 #. type: Bullet: '* '
 #: content/preferences-settings/config-directory.md
 #, no-wrap
-msgid "`lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lu: basic principles](../lua/basic-principles.md).\n"
+msgid "`lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lua: basic principles](../lua/basic-principles.md).\n"
 msgstr ""
 
 #. type: Bullet: '* '

--- a/po/content.uk.po
+++ b/po/content.uk.po
@@ -17905,7 +17905,7 @@ msgstr "Примітні файли/папки:"
 #. type: Bullet: '* '
 #: content/preferences-settings/config-directory.md
 #, no-wrap
-msgid "`lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lu: basic principles](../lua/basic-principles.md).\n"
+msgid "`lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lua: basic principles](../lua/basic-principles.md).\n"
 msgstr "`lua` (папка): Сценарії Lua. Примітка: починаючи з версії 5.6, сценарії Lua також постачаються в комплекті, і ця папка не є обов'язковою. Але вона буде врахована, якщо вона є. Власні сценарії можна додавати до підпапки. Див. [Lua: основні принципи](../lua/basic-principles.md).\n"
 
 #. type: Bullet: '* '

--- a/po/content.zh_Hant.po
+++ b/po/content.zh_Hant.po
@@ -16992,7 +16992,7 @@ msgstr ""
 #. type: Bullet: '* '
 #: content/preferences-settings/config-directory.md
 #, no-wrap
-msgid "`lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lu: basic principles](../lua/basic-principles.md).\n"
+msgid "`lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lua: basic principles](../lua/basic-principles.md).\n"
 msgstr ""
 
 #. type: Bullet: '* '

--- a/po/content.zh_cn.po
+++ b/po/content.zh_cn.po
@@ -16170,7 +16170,7 @@ msgstr ""
 #. type: Bullet: '* '
 #: content/preferences-settings/config-directory.md
 #, no-wrap
-msgid "`lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lu: basic principles](../lua/basic-principles.md).\n"
+msgid "`lua` (folder): Lua scripts.  Note: from 5.6 onwards Lua scripts are also bundled and this folder is not required. But it will be respected if present. Custom scripts can be added into a subfolder. See [Lua: basic principles](../lua/basic-principles.md).\n"
 msgstr ""
 
 #. type: Bullet: '* '


### PR DESCRIPTION
Some links say "Lu" instead of "Lua".