### PR TITLE
Update preferences for theme controls and some misc prefs

### DIFF
--- a/content/preferences-settings/general.md
+++ b/content/preferences-settings/general.md
@@ -12,6 +12,23 @@ interface language
 theme
 : Set the theme for the user interface. Aside from any aesthetic considerations, the recommended interface color for color evaluation is middle gray. Visual perception is affected by ambient brightness, and a low user interface brightness causes all kinds of illusions. Using a dark interface to retouch photos can therefore lead to excessive retouching (abuse of contrast and saturation) and to a photo that is too dark when printed. It is therefore highly recommended that you use one of the "grey" themes for retouching work as these are designed so that the user interface approximates middle gray. For those who have difficulty reading text in the default theme, darktable includes two "highcontrast" themes with white text on a dark background, but the caveats mentioned previously apply if you select one of them (default "darktable-elegant-grey").
 
+  Some elements of a theme are customizable by these additional preferences:
+
+  condensed module controls
+  : When enabled, controls in modules are made smaller and spacing between them is reduced (default off).
+  
+  rounded module headers
+  : When enabled, one corner (the corner furthest from the application's edge) of each module's header is rounded (default off).
+  
+  focused module border
+  : When a color is selected, the currently focused processing module has a border of the selected color (default none).
+  
+  expanded module border
+  : When a color is selected, each expanded processing module has a border of the selected color (default none). If [_expand a single processing module at a time_](darkroom.md#modules) is enabled, then _expanded module border_ has no effect as the expanded module is also the focussed module.
+  
+  accent color
+  : When a color is selected, the on/off button of a module is tinted with the selected color (default none).
+
 use system font size
 : Select this option to use the font size defined by your system. If unchecked, you may enter a custom font size in the box below (default on).
 

--- a/content/preferences-settings/miscellaneous.md
+++ b/content/preferences-settings/miscellaneous.md
@@ -18,6 +18,12 @@ load default shortcuts at startup
 scale slider step with min/max
 : When activated, the default step-size, when altering sliders, will depend on the current min/max values for that slider (default on).
 
+marker shape
+: Select the shape of the slider marker from triangle, circle, diamond or bar (default triangle).
+
+automatically update module name
+: If enabled, darktable will automatically update the module name to match a preset name or preset instance name, if present (default on).
+
 sort built-in presets first
 : Choose how the presets menu is sorted. If this option is enabled, built-in presets are shown first. If the option is disabled, user presets are shown first (default on).
 
@@ -35,6 +41,9 @@ always show panels' scrollbars
 
 duration of the ui transitions in ms
 : Defines how long modules and other ui elements will take to transition between states (expand/collapse). Set to 0 to disable animation (default 250ms).
+
+auto-scroll filmstrip to center on selected image
+: When enabled, the filmstrip in culling mode and in the darkroom automatically scrolls to center on the selected image (default on).
 
 position of the scopes module
 : Choose whether to show the [scopes](../module-reference/utility-modules/shared/scopes.md) module in the left or right panel (default right). (needs a restart)


### PR DESCRIPTION
Relates to two darktable PRs: https://github.com/darktable-org/darktable/pull/21431 and https://github.com/darktable-org/darktable/pull/21869

Only one of these PRs was merged, but the ideas are described across the two PRs.

Basically, adds some theme controls in the general preferences page.

This darktable change moves the _condensed module controls_ pref from miscellaneous to general, but when I looked it had never been added. Took this opportunity to add some missing prefs. 
