### PR TITLE
Add initial mcp doc

### DIFF
--- a/content/special-topics/program-invocation/darktable-mcp.md
+++ b/content/special-topics/program-invocation/darktable-mcp.md
@@ -6,7 +6,7 @@ weight: 65
 
 The `darktable-mcp` binary provides a [Module Context Protocol](https://modelcontextprotocol.io/docs/2026-07-28/getting-started/intro) (MCP) server interface for darktable.
 
-`darktable-mcp` lets an AI agent drive the raw pipeline over MCP, for example it can be used to:
+`darktable-mcp` can be used to let an AI agent drive the raw pipeline over MCP, for example it can be used to:
 * list modules and inspect their parameter schemas,
 * develop an image through a given module stack and get back a preview or per-channel statistics,
 * read history, styles and metadata from the library.

--- a/content/special-topics/program-invocation/darktable-mcp.md
+++ b/content/special-topics/program-invocation/darktable-mcp.md
@@ -28,7 +28,3 @@ darktable-mcp [--core <darktable options>]
 
   - `--library :memory:` - the database is kept in system memory - all changes are discarded when the application terminates.
   - `--conf write_sidecar_files=never` - never update XMP sidecars.
-
-
-
-

--- a/content/special-topics/program-invocation/darktable-mcp.md
+++ b/content/special-topics/program-invocation/darktable-mcp.md
@@ -48,7 +48,7 @@ The server exposes three groups of tools to the connected client.
 
 # connecting a client
 
-`darktable-mcp` is not run directly by the user -- it is launched by an MCP client, which talks to it over stdin and stdout. Most clients are configured with a JSON entry naming the command and its arguments:
+`darktable-mcp` is not run directly by the user -- it is launched by an MCP client, which talks to it over stdin and stdout. Most clients are configured with a JSON entry naming the command and its arguments, for instance like this example (which uses paths typical for a Linux system):
 
 ```json
 {

--- a/content/special-topics/program-invocation/darktable-mcp.md
+++ b/content/special-topics/program-invocation/darktable-mcp.md
@@ -13,7 +13,7 @@ The `darktable-mcp` binary provides a [Model Context Protocol](https://modelcont
 
 `darktable-mcp` is only built if darktable was compiled with the `USE_MCP` option, so the binary may not be present in all packages.
 
-Parameters are addressed by name through darktable's own introspection rather than by fixed offsets, so a stack stays valid across module versions, and renders run on a throwaway duplicate so the source image is never modified.
+Module parameters are referred to by name, so a set of instructions written for one version of darktable keeps working when a module is updated. Images are developed on a temporary copy, so neither the original file nor its existing edits are changed.
 
 It waits for commands on its stdin, and outputs responses to its stdout; stdout carries only JSON-RPC (darktable's own logging is redirected to stderr), so a client can speak the protocol cleanly.
 

--- a/content/special-topics/program-invocation/darktable-mcp.md
+++ b/content/special-topics/program-invocation/darktable-mcp.md
@@ -1,0 +1,34 @@
+---
+title: darktable-mcp
+id: darktable-mcp
+weight: 65
+---
+
+The `darktable-mcp` binary provides a [Module Context Protocol](https://modelcontextprotocol.io/docs/2026-07-28/getting-started/intro) (MCP) server interface for darktable.
+
+`darktable-mcp` lets an AI agent drive the raw pipeline over MCP, for example it can be used to:
+* list modules and inspect their parameter schemas,
+* develop an image through a given module stack and get back a preview or per-channel statistics,
+* read history, styles and metadata from the library.
+
+Parameters are addressed by name through darktable's own introspection rather than by fixed offsets, so a stack stays valid across module versions, and renders run on a throwaway duplicate so the source image is never modified.
+
+It waits for commands on its stdin, and outputs responses to its stdout; stdout carries only JSON-RPC (darktable's own logging is redirected to stderr), so a client can speak the protocol cleanly.
+
+darktable-mcp can be called with the following optional command line parameters:
+
+```
+darktable-mcp [--core <darktable options>]
+```
+
+`--core <darktable options>`
+: All command line parameters following `--core` are passed to the darktable core and handled as standard parameters. See the [`darktable binary`](./darktable.md) section for a detailed description.
+
+  Unless you override them, two defaults are injected:
+
+  - `--library :memory:` - the database is kept in system memory - all changes are discarded when the application terminates.
+  - `--conf write_sidecar_files=never` - never update XMP sidecars.
+
+
+
+

--- a/content/special-topics/program-invocation/darktable-mcp.md
+++ b/content/special-topics/program-invocation/darktable-mcp.md
@@ -4,12 +4,14 @@ id: darktable-mcp
 weight: 65
 ---
 
-The `darktable-mcp` binary provides a [Module Context Protocol](https://modelcontextprotocol.io/docs/2026-07-28/getting-started/intro) (MCP) server interface for darktable.
+The `darktable-mcp` binary provides a [Model Context Protocol](https://modelcontextprotocol.io/docs/2026-07-28/getting-started/intro) (MCP) server interface for darktable.
 
 `darktable-mcp` can be used to let an AI agent drive the raw pipeline over MCP, for example it can be used to:
 * list modules and inspect their parameter schemas,
 * develop an image through a given module stack and get back a preview or per-channel statistics,
 * read history, styles and metadata from the library.
+
+`darktable-mcp` is only built if darktable was compiled with the `USE_MCP` option, so the binary may not be present in all packages.
 
 Parameters are addressed by name through darktable's own introspection rather than by fixed offsets, so a stack stays valid across module versions, and renders run on a throwaway duplicate so the source image is never modified.
 
@@ -26,5 +28,41 @@ darktable-mcp [--core <darktable options>]
 
   Unless you override them, two defaults are injected:
 
-  - `--library :memory:` - the database is kept in system memory - all changes are discarded when the application terminates.
-  - `--conf write_sidecar_files=never` - never update XMP sidecars.
+  - `--library :memory:`
+    - the database is kept in system memory - all changes are discarded when the application terminates. Images are rendered and inspected by file path, and the library tools see nothing else.
+  - `--conf write_sidecar_files=never`
+    - never update XMP sidecars.
+
+To work against a real catalog instead, so that existing images, their edits and saved styles are visible, pass `--core --library /path/to/library.db`. darktable locks `library.db` and `data.db` while it runs, so this only works when the darktable GUI is not open on that library -- or against a copy of it. The default in-memory database takes no such lock and can be used while darktable is running.
+
+
+# available tools
+
+The server exposes three groups of tools to the connected client.
+
+*Introspection* tools describe darktable's modules: list the available processing modules, retrieve the parameters of a given module with their types, ranges and defaults, and convert between a module's stored parameter blob and named values. Each module also reports a link to its page in this manual.
+
+*Develop* tools process images: develop an image through its history stack, optionally with additional modules applied on top, and return either a preview image or per-channel statistics. Rendering is performed on a throwaway duplicate, so the source image is never modified.
+
+*Library* tools read and modify the catalog: list images, read an image's decoded history stack, list, apply, save and import styles, and export a developed image to a file. Note that several of these write to the library -- applying or saving a style changes the catalog, just as it would in the GUI.
+
+# connecting a client
+
+`darktable-mcp` is not run directly by the user -- it is launched by an MCP client, which talks to it over stdin and stdout. Most clients are configured with a JSON entry naming the command and its arguments:
+
+```json
+{
+  "mcpServers": {
+    "darktable": {
+      "command": "/usr/bin/darktable-mcp",
+      "args": ["--core",
+               "--configdir", "/home/user/.config/darktable-mcp",
+               "--cachedir",  "/home/user/.config/darktable-mcp/cache"]
+    }
+  }
+}
+```
+
+Give the server its own configuration and cache directories, as above. With the default in-memory library it can then be used at any time, including while darktable itself is open.
+
+Consult the documentation of your MCP client for where this configuration is stored, and whether it provides a command to add a server rather than editing the file by hand.


### PR DESCRIPTION
This relates to darktable PR: https://github.com/darktable-org/darktable/pull/21573

A new binary (`darktable-mcp`) has been added, and this dtdocs PR adds some minimal doc for it.

The content is taken from the [release notes entry](https://github.com/darktable-org/darktable/pull/22045/changes) and from the [README in the darktable repo](https://github.com/darktable-org/darktable/blob/master/src/mcp/README.md).

I'm not sure how much detail to add - I don't use any LLMs myself, so I would prefer to leave it pretty basic for now and hopefully it can be expanded when people gain some experience. What do you think?